### PR TITLE
chore: trigger one-time Android code sync

### DIFF
--- a/.sync-trigger
+++ b/.sync-trigger
@@ -1,0 +1,1 @@
+one-time bootstrap trigger

--- a/.sync-trigger
+++ b/.sync-trigger
@@ -1,1 +1,1 @@
-one-time bootstrap trigger
+one-time bootstrap trigger v2


### PR DESCRIPTION
This temporary PR exists only to trigger the repository bootstrap sync workflow. The workflow copies the current `android-port` implementation from `lladlam/MeloX`, imports the Android CI workflows and GPLv3 license, then deletes its own bootstrap workflow.