### PR TITLE
ci: reproduce playlist transition build

### DIFF
--- a/android/.ci-trigger
+++ b/android/.ci-trigger
@@ -1,0 +1,1 @@
+temporary CI reproduction

--- a/android/.ci-trigger
+++ b/android/.ci-trigger
@@ -1,1 +1,0 @@
-temporary CI reproduction v3

--- a/android/.ci-trigger
+++ b/android/.ci-trigger
@@ -1,1 +1,1 @@
-temporary CI reproduction
+temporary CI reproduction v2

--- a/android/.ci-trigger
+++ b/android/.ci-trigger
@@ -1,1 +1,1 @@
-temporary CI reproduction v2
+temporary CI reproduction v3

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/library/LibraryScreen.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/library/LibraryScreen.kt
@@ -155,6 +155,7 @@ fun LibraryScreen(
             },
             label = "library-playlist-detail-transition",
         ) { targetPlaylist ->
+            val playlistTransitionVisibilityScope = this
             if (targetPlaylist != null) {
                 MeloXPlaylistDetailScreen(
                     initialPlaylist = targetPlaylist,
@@ -242,7 +243,7 @@ fun LibraryScreen(
                                 onPlaylistClick = { selectedPlaylist = it },
                                 listState = playlistListState,
                                 sharedTransitionScope = sharedScope,
-                                animatedVisibilityScope = this,
+                                animatedVisibilityScope = playlistTransitionVisibilityScope,
                             )
 
                             MeloXLibraryPage.History -> MeloXLibrarySongsPage(


### PR DESCRIPTION
临时 PR，仅用于复现并抓取当前歌单 shared-element 转场的 Android CI 编译日志；不会合并。