### PR TITLE
chore: trigger playlist layering fix

### DIFF
--- a/.playlist-layer-trigger-branch
+++ b/.playlist-layer-trigger-branch
@@ -1,1 +1,1 @@
-base
+trigger

--- a/android/.ci-pr-verify-playlist-layer
+++ b/android/.ci-pr-verify-playlist-layer
@@ -1,0 +1,1 @@
+verify current main merge


### PR DESCRIPTION
临时 PR，仅用于触发一次性修复工作流：统一歌单详情背景取色逻辑，并修正全屏播放器与歌单详情的返回层级。不会合并。