### PR TITLE
ci: apply playlist interruption and back-stack fix

### DIFF
--- a/.playlist-interrupt-trigger
+++ b/.playlist-interrupt-trigger
@@ -1,1 +1,1 @@
-run-v2
+pr-run


### PR DESCRIPTION
临时 PR，仅用于触发经过编译验证的一次性修复：1）全屏播放器显示时禁用歌单详情 BackHandler，确保返回顺序为播放器→歌单→列表；2）保留 AnimatedContent 中被打断的旧歌单退场，并让新打开歌单保持更高层级。不会合并。