### PR TITLE
refactor: migrate bottom chrome to AndroidLiquidGlass

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -49,9 +49,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
     implementation("androidx.navigation:navigation-compose:2.9.8")
 
-    // Miuix's official liquid-glass demo is built on this backdrop/RuntimeShader module.
-    // Keep minSdk 26: all shader paths are runtime-gated and fall back below API 33.
-    implementation("top.yukonga.miuix.kmp:miuix-blur-android:0.9.1")
+    // Kyant0/AndroidLiquidGlass. One shared LayerBackdrop is recorded at the app root;
+    // individual glass controls only sample that source, avoiding nested capture layers.
+    implementation("io.github.kyant0:backdrop:2.0.0")
 
     implementation("androidx.media3:media3-common:1.10.1")
     implementation("androidx.media3:media3-datasource:1.10.1")

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -6,35 +6,15 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -45,35 +25,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kyant.backdrop.backdrops.layerBackdrop
+import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import com.lladlam.melox.core.account.rememberNeteaseSessionStore
 import com.lladlam.melox.ui.account.NeteaseLoginScreen
-import com.lladlam.melox.ui.glass.meloXLiquidGlass
 import com.lladlam.melox.ui.library.LibraryScreen
 import com.lladlam.melox.ui.player.MeloXIOSMiniPlayer
 import com.lladlam.melox.ui.player.MeloXIOSNowPlayingSharedHost
 import com.lladlam.melox.ui.player.rememberMeloXPlaybackUiState
 import com.lladlam.melox.ui.search.SearchScreen
 import com.lladlam.melox.ui.settings.SettingsScreen
-import top.yukonga.miuix.kmp.blur.LayerBackdrop
-import top.yukonga.miuix.kmp.blur.layerBackdrop
-import top.yukonga.miuix.kmp.blur.rememberLayerBackdrop
 
 enum class AppTab(val title: String) {
     Home("首页"),
@@ -82,8 +52,6 @@ enum class AppTab(val title: String) {
     Settings("设置"),
     Search("搜索"),
 }
-
-private val MeloXAccent = Color(0xFFFF3147)
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -148,6 +116,9 @@ fun MeloXApp(
         SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
             val sharedScope = this
             val fullPlayerVisible = showNowPlaying && playbackState.hasMedia
+
+            // One and only one recording layer for bottom chrome. AndroidLiquidGlass
+            // controls sample this source instead of recording their own backdrops.
             val glassBackdrop = rememberLayerBackdrop()
 
             Scaffold(
@@ -175,9 +146,6 @@ fun MeloXApp(
                         )
                         AppTab.Library -> LibraryScreen(
                             session = neteaseSession,
-                            // Back ownership is state-based instead of relying on
-                            // composition order. The full player exclusively owns
-                            // back while it is visible.
                             playlistBackEnabled = !fullPlayerVisible,
                             onLogin = {
                                 loginReturnTab = AppTab.Library
@@ -251,9 +219,6 @@ fun MeloXApp(
                 )
             }
 
-            // Compose dispatches back to the last composed enabled handler. Keep
-            // the full player handler after LibraryScreen so a player opened from
-            // playlist detail is dismissed before the playlist itself is popped.
             BackHandler(enabled = fullPlayerVisible && !showNeteaseLogin) {
                 showNowPlaying = false
             }
@@ -297,360 +262,3 @@ private fun MeloXSectionShell(
         )
     }
 }
-
-@Composable
-private fun MeloXBottomChrome(
-    selectedTab: AppTab,
-    onSelect: (AppTab) -> Unit,
-    hasMedia: Boolean,
-    minimized: Boolean,
-    backdrop: LayerBackdrop?,
-    modifier: Modifier = Modifier,
-    miniPlayer: @Composable () -> Unit,
-) {
-    val rawProgress by animateFloatAsState(
-        targetValue = if (minimized) 1f else 0f,
-        animationSpec = spring(
-            dampingRatio = 0.90f,
-            stiffness = 330f,
-            visibilityThreshold = 0.001f,
-        ),
-        label = "melox-tab-minimize-progress",
-    )
-    val progress = rawProgress.coerceIn(0f, 1f)
-
-    val labelStage = smoothStep(progress, 0.00f, 0.32f)
-    val sizeStage = smoothStep(progress, 0.00f, 0.36f)
-    val shrinkStage = smoothStep(progress, 0.25f, 0.82f)
-    val dropStage = smoothStep(progress, 0.78f, 1.00f)
-
-    val navHeight = lerpDp(66.dp, 58.dp, sizeStage)
-    val searchSize = lerpDp(66.dp, 58.dp, sizeStage)
-    val expandedChromeHeight = if (hasMedia) 137.dp else 72.dp
-    val chromeHeight = lerpDp(expandedChromeHeight, 64.dp, dropStage)
-    val labelAlpha = 1f - labelStage
-    val expandedLayerAlpha = 1f - smoothStep(progress, 0.43f, 0.72f)
-    val compactLayerAlpha = smoothStep(progress, 0.52f, 0.82f)
-
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .navigationBarsPadding()
-            .padding(bottom = 5.dp),
-    ) {
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(chromeHeight),
-        ) {
-            val horizontalMargin = 14.dp
-            val compactSize = 58.dp
-            val expandedGap = 9.dp
-            val compactGap = 4.dp
-            val expandedNavWidth = maxWidth - horizontalMargin * 2 - expandedGap - 66.dp
-            val navWidth = lerpDp(expandedNavWidth, compactSize, shrinkStage)
-            val navRadius = lerpDp(34.dp, 29.dp, shrinkStage)
-            val navShape = RoundedCornerShape(navRadius)
-            val primaryTabs = listOf(
-                AppTab.Home to RootGlyph.Home,
-                AppTab.Explore to RootGlyph.Explore,
-                AppTab.Library to RootGlyph.Library,
-                AppTab.Settings to RootGlyph.Settings,
-            )
-
-            val desiredCompactMiniVisibleWidth =
-                (maxWidth - horizontalMargin * 2 - compactSize * 2 - compactGap * 2)
-                    .coerceAtLeast(80.dp)
-            val compactMiniWrapperWidth =
-                (desiredCompactMiniVisibleWidth + 28.dp).coerceAtMost(maxWidth)
-            val compactMiniWrapperX = horizontalMargin + compactSize + compactGap - 14.dp
-            val miniWrapperWidth = lerpDp(maxWidth, compactMiniWrapperWidth, shrinkStage)
-            val miniWrapperX = lerpDp(0.dp, compactMiniWrapperX, shrinkStage)
-            val miniLift = lerpDp(72.dp, 0.dp, shrinkStage)
-
-            if (hasMedia) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .offset(
-                            x = miniWrapperX,
-                            y = -3.dp - miniLift,
-                        )
-                        .width(miniWrapperWidth),
-                ) {
-                    miniPlayer()
-                }
-            }
-
-            val dark = isSystemInDarkTheme()
-
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .offset(x = horizontalMargin, y = -3.dp)
-                    .width(navWidth)
-                    .height(navHeight)
-                    .meloXLiquidGlass(
-                        backdrop = backdrop,
-                        shape = navShape,
-                        tint = bottomLiquidGlassTint(),
-                        fallbackTint = bottomGlassFallbackColor(),
-                        blurRadius = 6.dp,
-                        refractionHeight = 0.dp,
-                        refractionAmount = 0.dp,
-                        chromaticAberration = 0f,
-                    )
-                    .pointerInput(progress, selectedTab) {
-                        detectTapGestures { tap ->
-                            if (progress < 0.56f) {
-                                val segmentWidth = size.width / 4f
-                                val index = (tap.x / segmentWidth).toInt().coerceIn(0, 3)
-                                onSelect(primaryTabs[index].first)
-                            } else if (progress >= 0.68f) {
-                                onSelect(selectedTab)
-                            }
-                        }
-                    },
-                shape = navShape,
-                color = Color.Transparent,
-                border = null,
-                shadowElevation = lerpDp(2.dp, 4.dp, progress),
-                tonalElevation = 0.dp,
-            ) {
-                Box(Modifier.fillMaxSize()) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .graphicsLayer { alpha = expandedLayerAlpha }
-                            .padding(horizontal = 5.dp, vertical = 5.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        primaryTabs.forEach { (tab, glyph) ->
-                            RootTabButton(
-                                tab = tab,
-                                glyph = glyph,
-                                selected = selectedTab == tab,
-                                labelAlpha = labelAlpha,
-                                dark = dark,
-                            )
-                        }
-                    }
-
-                    if (progress > 0.50f) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .graphicsLayer { alpha = compactLayerAlpha },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            RootGlyphIcon(
-                                glyph = selectedTab.rootGlyph(),
-                                modifier = Modifier.size(27.dp),
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
-                        }
-                    }
-                }
-            }
-
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .offset(x = -horizontalMargin, y = -3.dp)
-                    .size(searchSize)
-                    .meloXLiquidGlass(
-                        backdrop = backdrop,
-                        shape = CircleShape,
-                        tint = bottomLiquidGlassTint(),
-                        fallbackTint = bottomGlassFallbackColor(),
-                        blurRadius = 6.dp,
-                        refractionHeight = 0.dp,
-                        refractionAmount = 0.dp,
-                        chromaticAberration = 0f,
-                    )
-                    .clickable { onSelect(AppTab.Search) },
-                shape = CircleShape,
-                color = Color.Transparent,
-                border = null,
-                shadowElevation = lerpDp(2.dp, 4.dp, progress),
-                tonalElevation = 0.dp,
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    RootGlyphIcon(
-                        glyph = RootGlyph.Search,
-                        modifier = Modifier.size(lerpDp(31.dp, 29.dp, sizeStage)),
-                        color = if (selectedTab == AppTab.Search) {
-                            MeloXAccent
-                        } else {
-                            MaterialTheme.colorScheme.onSurface
-                        },
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun bottomLiquidGlassTint(): Color =
-    if (isSystemInDarkTheme()) {
-        Color.Black.copy(alpha = 0.10f)
-    } else {
-        Color.White.copy(alpha = 0.12f)
-    }
-
-@Composable
-private fun bottomGlassFallbackColor(): Color =
-    if (isSystemInDarkTheme()) {
-        MaterialTheme.colorScheme.surface.copy(alpha = 0.58f)
-    } else {
-        Color.White.copy(alpha = 0.56f)
-    }
-
-@Composable
-private fun RowScope.RootTabButton(
-    tab: AppTab,
-    glyph: RootGlyph,
-    selected: Boolean,
-    labelAlpha: Float,
-    dark: Boolean,
-) {
-    val foreground = if (selected) MeloXAccent else MaterialTheme.colorScheme.onSurface
-    val selectedBackground = when {
-        !selected -> Color.Transparent
-        dark -> Color.White.copy(alpha = 0.08f)
-        else -> Color.White.copy(alpha = 0.24f)
-    }
-    Column(
-        modifier = Modifier
-            .weight(1f)
-            .fillMaxHeight()
-            .clip(RoundedCornerShape(28.dp))
-            .background(selectedBackground)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        RootGlyphIcon(glyph = glyph, modifier = Modifier.size(26.dp), color = foreground)
-        Text(
-            text = tab.title,
-            modifier = Modifier.graphicsLayer { alpha = labelAlpha },
-            fontSize = 10.sp,
-            lineHeight = 12.sp,
-            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
-            color = foreground,
-        )
-    }
-}
-
-private enum class RootGlyph { Home, Explore, Library, Settings, Search }
-
-private fun AppTab.rootGlyph(): RootGlyph = when (this) {
-    AppTab.Home -> RootGlyph.Home
-    AppTab.Explore -> RootGlyph.Explore
-    AppTab.Library -> RootGlyph.Library
-    AppTab.Settings -> RootGlyph.Settings
-    AppTab.Search -> RootGlyph.Search
-}
-
-@Composable
-private fun RootGlyphIcon(
-    glyph: RootGlyph,
-    modifier: Modifier,
-    color: Color,
-) {
-    Canvas(modifier) {
-        val w = size.width
-        val h = size.height
-        val stroke = size.minDimension * 0.115f
-
-        when (glyph) {
-            RootGlyph.Home -> {
-                val roof = Path().apply {
-                    moveTo(w * 0.10f, h * 0.48f)
-                    lineTo(w * 0.50f, h * 0.14f)
-                    lineTo(w * 0.90f, h * 0.48f)
-                }
-                drawPath(roof, color, style = Stroke(width = stroke, cap = StrokeCap.Round))
-                drawRoundRect(
-                    color = color,
-                    topLeft = Offset(w * 0.24f, h * 0.43f),
-                    size = Size(w * 0.52f, h * 0.43f),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(w * 0.05f),
-                    style = Stroke(width = stroke),
-                )
-            }
-            RootGlyph.Explore -> {
-                drawCircle(color, radius = w * 0.35f, style = Stroke(width = stroke))
-                val needle = Path().apply {
-                    moveTo(w * 0.38f, h * 0.62f)
-                    lineTo(w * 0.57f, h * 0.36f)
-                    lineTo(w * 0.63f, h * 0.55f)
-                    close()
-                }
-                drawPath(needle, color)
-            }
-            RootGlyph.Library -> {
-                val p = Path().apply {
-                    moveTo(w * 0.26f, h * 0.22f)
-                    lineTo(w * 0.26f, h * 0.72f)
-                    cubicTo(w * 0.26f, h * 0.83f, w * 0.10f, h * 0.84f, w * 0.10f, h * 0.70f)
-                    cubicTo(w * 0.10f, h * 0.57f, w * 0.29f, h * 0.55f, w * 0.37f, h * 0.62f)
-                    lineTo(w * 0.37f, h * 0.28f)
-                    lineTo(w * 0.83f, h * 0.18f)
-                    lineTo(w * 0.83f, h * 0.61f)
-                    cubicTo(w * 0.83f, h * 0.74f, w * 0.66f, h * 0.77f, w * 0.61f, h * 0.66f)
-                }
-                drawPath(p, color, style = Stroke(width = stroke, cap = StrokeCap.Round))
-            }
-            RootGlyph.Settings -> {
-                drawCircle(color, radius = w * 0.33f, style = Stroke(width = stroke))
-                drawCircle(color, radius = w * 0.095f)
-                repeat(8) { index ->
-                    val angle = Math.toRadians((index * 45.0) - 90.0)
-                    val cx = w / 2f
-                    val cy = h / 2f
-                    val r1 = w * 0.37f
-                    val r2 = w * 0.47f
-                    drawLine(
-                        color = color,
-                        start = Offset(
-                            cx + kotlin.math.cos(angle).toFloat() * r1,
-                            cy + kotlin.math.sin(angle).toFloat() * r1,
-                        ),
-                        end = Offset(
-                            cx + kotlin.math.cos(angle).toFloat() * r2,
-                            cy + kotlin.math.sin(angle).toFloat() * r2,
-                        ),
-                        strokeWidth = stroke,
-                        cap = StrokeCap.Round,
-                    )
-                }
-            }
-            RootGlyph.Search -> {
-                drawCircle(
-                    color = color,
-                    radius = w * 0.29f,
-                    center = Offset(w * 0.43f, h * 0.40f),
-                    style = Stroke(width = stroke),
-                )
-                drawLine(
-                    color = color,
-                    start = Offset(w * 0.64f, h * 0.62f),
-                    end = Offset(w * 0.86f, h * 0.84f),
-                    strokeWidth = stroke,
-                    cap = StrokeCap.Round,
-                )
-            }
-        }
-    }
-}
-
-private fun smoothStep(value: Float, start: Float, end: Float): Float {
-    if (end <= start) return if (value >= end) 1f else 0f
-    val t = ((value - start) / (end - start)).coerceIn(0f, 1f)
-    return t * t * (3f - 2f * t)
-}
-
-private fun lerpDp(start: Dp, end: Dp, progress: Float): Dp =
-    (start.value + (end.value - start.value) * progress.coerceIn(0f, 1f)).dp

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXBottomChrome.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXBottomChrome.kt
@@ -1,0 +1,398 @@
+package com.lladlam.melox.ui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kyant.backdrop.backdrops.LayerBackdrop
+import com.lladlam.melox.ui.glass.meloXLiquidGlass
+
+private val MeloXBottomAccent = Color(0xFFFF3147)
+
+/**
+ * Floating MeloX bottom chrome.
+ *
+ * Performance rule: all surfaces below sample the one LayerBackdrop owned by MeloXApp.
+ * There is no nested/combined backdrop and no hidden secondary capture layer.
+ */
+@Composable
+internal fun MeloXBottomChrome(
+    selectedTab: AppTab,
+    onSelect: (AppTab) -> Unit,
+    hasMedia: Boolean,
+    minimized: Boolean,
+    backdrop: LayerBackdrop,
+    modifier: Modifier = Modifier,
+    miniPlayer: @Composable () -> Unit,
+) {
+    val rawProgress by animateFloatAsState(
+        targetValue = if (minimized) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = 0.90f,
+            stiffness = 330f,
+            visibilityThreshold = 0.001f,
+        ),
+        label = "melox-tab-minimize-progress",
+    )
+    val progress = rawProgress.coerceIn(0f, 1f)
+
+    val labelStage = smoothStep(progress, 0.00f, 0.32f)
+    val sizeStage = smoothStep(progress, 0.00f, 0.36f)
+    val shrinkStage = smoothStep(progress, 0.25f, 0.82f)
+    val dropStage = smoothStep(progress, 0.78f, 1.00f)
+
+    val navHeight = lerpDp(66.dp, 58.dp, sizeStage)
+    val searchSize = lerpDp(66.dp, 58.dp, sizeStage)
+    val expandedChromeHeight = if (hasMedia) 137.dp else 72.dp
+    val chromeHeight = lerpDp(expandedChromeHeight, 64.dp, dropStage)
+    val labelAlpha = 1f - labelStage
+    val expandedLayerAlpha = 1f - smoothStep(progress, 0.43f, 0.72f)
+    val compactLayerAlpha = smoothStep(progress, 0.52f, 0.82f)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(bottom = 5.dp),
+    ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(chromeHeight),
+        ) {
+            val horizontalMargin = 14.dp
+            val compactSize = 58.dp
+            val expandedGap = 9.dp
+            val compactGap = 4.dp
+            val expandedNavWidth = maxWidth - horizontalMargin * 2 - expandedGap - 66.dp
+            val navWidth = lerpDp(expandedNavWidth, compactSize, shrinkStage)
+            val navRadius = lerpDp(34.dp, 29.dp, shrinkStage)
+            val navShape = RoundedCornerShape(navRadius)
+            val primaryTabs = listOf(
+                AppTab.Home to RootGlyph.Home,
+                AppTab.Explore to RootGlyph.Explore,
+                AppTab.Library to RootGlyph.Library,
+                AppTab.Settings to RootGlyph.Settings,
+            )
+
+            val desiredCompactMiniVisibleWidth =
+                (maxWidth - horizontalMargin * 2 - compactSize * 2 - compactGap * 2)
+                    .coerceAtLeast(80.dp)
+            val compactMiniWrapperWidth =
+                (desiredCompactMiniVisibleWidth + 28.dp).coerceAtMost(maxWidth)
+            val compactMiniWrapperX = horizontalMargin + compactSize + compactGap - 14.dp
+            val miniWrapperWidth = lerpDp(maxWidth, compactMiniWrapperWidth, shrinkStage)
+            val miniWrapperX = lerpDp(0.dp, compactMiniWrapperX, shrinkStage)
+            val miniLift = lerpDp(72.dp, 0.dp, shrinkStage)
+
+            if (hasMedia) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .offset(
+                            x = miniWrapperX,
+                            y = -3.dp - miniLift,
+                        )
+                        .width(miniWrapperWidth),
+                ) {
+                    miniPlayer()
+                }
+            }
+
+            val dark = isSystemInDarkTheme()
+            val navTint = if (dark) {
+                Color.Black.copy(alpha = 0.08f)
+            } else {
+                Color.White.copy(alpha = 0.10f)
+            }
+            val fallback = if (dark) {
+                MaterialTheme.colorScheme.surface.copy(alpha = 0.60f)
+            } else {
+                Color.White.copy(alpha = 0.62f)
+            }
+
+            // The navigation capsule owns all four tab hit regions. This avoids invisible
+            // child overlays stealing taps while the capsule is morphing into compact mode.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .offset(x = horizontalMargin, y = -3.dp)
+                    .width(navWidth)
+                    .height(navHeight)
+                    .meloXLiquidGlass(
+                        backdrop = backdrop,
+                        shape = navShape,
+                        tint = navTint,
+                        fallbackTint = fallback,
+                        blurRadius = 8.dp,
+                        refractionHeight = 12.dp,
+                        refractionAmount = 16.dp,
+                        enableLens = true,
+                        highlightAlpha = 0.16f,
+                        shadowAlpha = 0.10f,
+                    )
+                    .pointerInput(progress, selectedTab) {
+                        detectTapGestures { tap ->
+                            if (progress < 0.56f) {
+                                val segmentWidth = size.width / 4f
+                                val index = (tap.x / segmentWidth).toInt().coerceIn(0, 3)
+                                onSelect(primaryTabs[index].first)
+                            } else if (progress >= 0.68f) {
+                                onSelect(selectedTab)
+                            }
+                        }
+                    },
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { alpha = expandedLayerAlpha }
+                        .padding(horizontal = 5.dp, vertical = 5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    primaryTabs.forEach { (tab, glyph) ->
+                        RootTabButton(
+                            tab = tab,
+                            glyph = glyph,
+                            selected = selectedTab == tab,
+                            labelAlpha = labelAlpha,
+                        )
+                    }
+                }
+
+                if (progress > 0.50f) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer { alpha = compactLayerAlpha },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        RootGlyphIcon(
+                            glyph = selectedTab.rootGlyph(),
+                            modifier = Modifier.size(27.dp),
+                            color = if (selectedTab == AppTab.Search) {
+                                MaterialTheme.colorScheme.onSurface
+                            } else {
+                                MeloXBottomAccent
+                            },
+                        )
+                    }
+                }
+            }
+
+            // AndroidLiquidGlass can render the circular mask directly, so the old Miuix
+            // CircleShape fallback (which produced a polygon/hexagon artifact) is gone.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .offset(x = -horizontalMargin, y = -3.dp)
+                    .size(searchSize)
+                    .meloXLiquidGlass(
+                        backdrop = backdrop,
+                        shape = CircleShape,
+                        tint = navTint,
+                        fallbackTint = fallback,
+                        blurRadius = 6.dp,
+                        refractionHeight = 10.dp,
+                        refractionAmount = 12.dp,
+                        enableLens = true,
+                        highlightAlpha = 0.18f,
+                        shadowAlpha = 0.10f,
+                    )
+                    .clip(CircleShape)
+                    .pointerInput(Unit) {
+                        detectTapGestures { onSelect(AppTab.Search) }
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                RootGlyphIcon(
+                    glyph = RootGlyph.Search,
+                    modifier = Modifier.size(lerpDp(31.dp, 29.dp, sizeStage)),
+                    color = if (selectedTab == AppTab.Search) {
+                        MeloXBottomAccent
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.RootTabButton(
+    tab: AppTab,
+    glyph: RootGlyph,
+    selected: Boolean,
+    labelAlpha: Float,
+) {
+    val foreground = if (selected) MeloXBottomAccent else MaterialTheme.colorScheme.onSurface
+
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxHeight()
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        RootGlyphIcon(glyph = glyph, modifier = Modifier.size(26.dp), color = foreground)
+        Text(
+            text = tab.title,
+            modifier = Modifier.graphicsLayer { alpha = labelAlpha },
+            fontSize = 10.sp,
+            lineHeight = 12.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            color = foreground,
+        )
+    }
+}
+
+private enum class RootGlyph { Home, Explore, Library, Settings, Search }
+
+private fun AppTab.rootGlyph(): RootGlyph = when (this) {
+    AppTab.Home -> RootGlyph.Home
+    AppTab.Explore -> RootGlyph.Explore
+    AppTab.Library -> RootGlyph.Library
+    AppTab.Settings -> RootGlyph.Settings
+    AppTab.Search -> RootGlyph.Search
+}
+
+@Composable
+private fun RootGlyphIcon(
+    glyph: RootGlyph,
+    modifier: Modifier,
+    color: Color,
+) {
+    Canvas(modifier) {
+        val w = size.width
+        val h = size.height
+        val stroke = size.minDimension * 0.115f
+
+        when (glyph) {
+            RootGlyph.Home -> {
+                val roof = Path().apply {
+                    moveTo(w * 0.10f, h * 0.48f)
+                    lineTo(w * 0.50f, h * 0.14f)
+                    lineTo(w * 0.90f, h * 0.48f)
+                }
+                drawPath(roof, color, style = Stroke(width = stroke, cap = StrokeCap.Round))
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.24f, h * 0.43f),
+                    size = Size(w * 0.52f, h * 0.43f),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(w * 0.05f),
+                    style = Stroke(width = stroke),
+                )
+            }
+            RootGlyph.Explore -> {
+                drawCircle(color, radius = w * 0.35f, style = Stroke(width = stroke))
+                val needle = Path().apply {
+                    moveTo(w * 0.38f, h * 0.62f)
+                    lineTo(w * 0.57f, h * 0.36f)
+                    lineTo(w * 0.63f, h * 0.55f)
+                    close()
+                }
+                drawPath(needle, color)
+            }
+            RootGlyph.Library -> {
+                val path = Path().apply {
+                    moveTo(w * 0.26f, h * 0.22f)
+                    lineTo(w * 0.26f, h * 0.72f)
+                    cubicTo(w * 0.26f, h * 0.83f, w * 0.10f, h * 0.84f, w * 0.10f, h * 0.70f)
+                    cubicTo(w * 0.10f, h * 0.57f, w * 0.29f, h * 0.55f, w * 0.37f, h * 0.62f)
+                    lineTo(w * 0.37f, h * 0.28f)
+                    lineTo(w * 0.83f, h * 0.18f)
+                    lineTo(w * 0.83f, h * 0.61f)
+                    cubicTo(w * 0.83f, h * 0.74f, w * 0.66f, h * 0.77f, w * 0.61f, h * 0.66f)
+                }
+                drawPath(path, color, style = Stroke(width = stroke, cap = StrokeCap.Round))
+            }
+            RootGlyph.Settings -> {
+                drawCircle(color, radius = w * 0.33f, style = Stroke(width = stroke))
+                drawCircle(color, radius = w * 0.095f)
+                repeat(8) { index ->
+                    val angle = Math.toRadians((index * 45.0) - 90.0)
+                    val cx = w / 2f
+                    val cy = h / 2f
+                    val r1 = w * 0.37f
+                    val r2 = w * 0.47f
+                    drawLine(
+                        color = color,
+                        start = Offset(
+                            cx + kotlin.math.cos(angle).toFloat() * r1,
+                            cy + kotlin.math.sin(angle).toFloat() * r1,
+                        ),
+                        end = Offset(
+                            cx + kotlin.math.cos(angle).toFloat() * r2,
+                            cy + kotlin.math.sin(angle).toFloat() * r2,
+                        ),
+                        strokeWidth = stroke,
+                        cap = StrokeCap.Round,
+                    )
+                }
+            }
+            RootGlyph.Search -> {
+                drawCircle(
+                    color = color,
+                    radius = w * 0.29f,
+                    center = Offset(w * 0.43f, h * 0.40f),
+                    style = Stroke(width = stroke),
+                )
+                drawLine(
+                    color = color,
+                    start = Offset(w * 0.64f, h * 0.62f),
+                    end = Offset(w * 0.86f, h * 0.84f),
+                    strokeWidth = stroke,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+    }
+}
+
+private fun smoothStep(value: Float, start: Float, end: Float): Float {
+    if (end <= start) return if (value >= end) 1f else 0f
+    val t = ((value - start) / (end - start)).coerceIn(0f, 1f)
+    return t * t * (3f - 2f * t)
+}
+
+private fun lerpDp(start: Dp, end: Dp, progress: Float): Dp =
+    (start.value + (end.value - start.value) * progress.coerceIn(0f, 1f)).dp

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXLiquidGlass.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXLiquidGlass.kt
@@ -1,86 +1,74 @@
 // Copyright 2026 MeloX contributors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Liquid-glass lens code is adapted from compose-miuix-ui/miuix v0.9.1
-// example/component/liquid/Lens.kt, which is itself adapted from
-// Kyant0/AndroidLiquidGlass. Both upstream sources are Apache-2.0.
+// Glass rendering is provided by Kyant0/AndroidLiquidGlass (Backdrop), Apache-2.0.
 
 package com.lladlam.melox.ui.glass
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastCoerceAtMost
-import top.yukonga.miuix.kmp.blur.BackdropEffectScope
-import top.yukonga.miuix.kmp.blur.LayerBackdrop
-import top.yukonga.miuix.kmp.blur.blur
-import top.yukonga.miuix.kmp.blur.colorControls
-import top.yukonga.miuix.kmp.blur.drawBackdrop
-import top.yukonga.miuix.kmp.blur.isRuntimeShaderSupported
-import top.yukonga.miuix.kmp.blur.runtimeShaderEffect
+import com.kyant.backdrop.Backdrop
+import com.kyant.backdrop.drawBackdrop
+import com.kyant.backdrop.effects.blur
+import com.kyant.backdrop.effects.lens
+import com.kyant.backdrop.effects.vibrancy
+import com.kyant.backdrop.highlight.Highlight
+import com.kyant.backdrop.shadow.Shadow
 
 /**
- * MeloX bottom-chrome glass, following Miuix's official LiquidGlassNavigationBar recipe:
- * captured backdrop -> vibrancy -> gaussian blur -> rounded-rect refraction lens.
+ * Thin MeloX styling layer over Kyant0/AndroidLiquidGlass.
  *
- * Android RuntimeShader is available from API 33. Older Android versions keep the same
- * geometry and interaction but fall back to a translucent surface instead of crashing.
- *
- * Small circular controls deliberately use the fallback surface even when RuntimeShader is
- * available. Miuix drawBackdrop currently produces a visible polygon/mask artifact on the
- * compact search button on affected devices; avoiding that experimental mask path removes
- * the artifact without changing the larger pill-shaped backdrop surfaces.
+ * The app owns a single LayerBackdrop at the root. Every bottom-chrome surface samples that
+ * same recording layer; this function never allocates another backdrop, combined backdrop,
+ * or hidden capture layer. Geometry can therefore animate without multiplying capture cost.
  */
 internal fun Modifier.meloXLiquidGlass(
-    backdrop: LayerBackdrop?,
+    backdrop: Backdrop?,
     shape: Shape,
     tint: Color,
     fallbackTint: Color,
     alpha: Float = 1f,
-    blurRadius: Dp = 4.dp,
-    refractionHeight: Dp = 24.dp,
-    refractionAmount: Dp = 24.dp,
-    chromaticAberration: Float = 0.12f,
-    vibrancySaturation: Float = 1.5f,
-    vibrancyContrast: Float = 1f,
+    blurRadius: Dp = 8.dp,
+    refractionHeight: Dp = 12.dp,
+    refractionAmount: Dp = 16.dp,
+    enableLens: Boolean = true,
+    highlightAlpha: Float = 0.16f,
+    shadowAlpha: Float = 0.10f,
 ): Modifier {
     val effectAlpha = alpha.coerceIn(0f, 1f)
 
-    // CircleShape is used by the compact search control. On affected Android/HyperOS
-    // devices, drawBackdrop's small circular mask composites as a polygon/hexagon.
-    // Do not send circles through that experimental shader path until the upstream
-    // implementation is stable for this geometry.
-    val useStableFallback = shape == CircleShape
-    if (backdrop == null || !isRuntimeShaderSupported() || useStableFallback) {
-        return this.background(
+    if (backdrop == null) {
+        return background(
             color = fallbackTint.copy(alpha = fallbackTint.alpha * effectAlpha),
             shape = shape,
         )
     }
 
-    return this.drawBackdrop(
+    return drawBackdrop(
         backdrop = backdrop,
         shape = { shape },
         effects = {
-            // Matches the padding used by Miuix's LiquidGlassNavigationBar so the
-            // refracted rim never samples outside the captured layer.
-            padding = maxOf(padding, 40.dp.toPx())
-            meloXVibrancy(
-                saturation = vibrancySaturation,
-                contrast = vibrancyContrast,
-            )
-            blur(blurRadius.toPx(), blurRadius.toPx())
-            meloXLens(
-                refractionHeight = refractionHeight.toPx(),
-                refractionAmount = refractionAmount.toPx(),
-                chromaticAberration = chromaticAberration,
-            )
+            vibrancy()
+            if (blurRadius > 0.dp) {
+                blur(blurRadius.toPx())
+            }
+            if (enableLens && refractionHeight > 0.dp && refractionAmount > 0.dp) {
+                lens(
+                    refractionHeight.toPx(),
+                    refractionAmount.toPx(),
+                    chromaticAberration = false,
+                )
+            }
+        },
+        highlight = {
+            Highlight.Default.copy(alpha = highlightAlpha.coerceIn(0f, 1f) * effectAlpha)
+        },
+        shadow = {
+            Shadow(alpha = shadowAlpha.coerceIn(0f, 1f) * effectAlpha)
         },
         layerBlock = {
             this.alpha = effectAlpha
@@ -90,234 +78,3 @@ internal fun Modifier.meloXLiquidGlass(
         },
     )
 }
-
-/** Lightweight counterpart of the Miuix example's vibrancy(). */
-private fun BackdropEffectScope.meloXVibrancy(
-    saturation: Float,
-    contrast: Float,
-) {
-    colorControls(
-        brightness = 0f,
-        contrast = contrast,
-        saturation = saturation,
-    )
-}
-
-/**
- * Rounded-rect refraction lens with subtle chromatic dispersion.
- * Ported from Miuix v0.9.1's liquid-glass example.
- */
-private fun BackdropEffectScope.meloXLens(
-    refractionHeight: Float,
-    refractionAmount: Float,
-    depthEffect: Boolean = false,
-    chromaticAberration: Float = 0f,
-) {
-    if (!isRuntimeShaderSupported()) return
-    if (refractionHeight <= 0f || refractionAmount <= 0f) return
-
-    if (padding < refractionAmount) {
-        padding = refractionAmount
-    }
-
-    val radii = roundedRectCornerRadii() ?: return
-    val dispersionEnabled = chromaticAberration > 0f
-    val shaderString = if (dispersionEnabled) {
-        ROUNDED_RECT_REFRACTION_WITH_DISPERSION_SHADER
-    } else {
-        ROUNDED_RECT_REFRACTION_SHADER
-    }
-    val key = if (dispersionEnabled) "MeloXLiquidGlassLensDispersion" else "MeloXLiquidGlassLens"
-
-    val sf = downscaleFactor.coerceAtLeast(1).toFloat()
-    val scaledSizeW = size.width / sf
-    val scaledSizeH = size.height / sf
-    val scaledPadding = padding / sf
-    val scaledRefractionHeight = refractionHeight / sf
-    val scaledRefractionAmount = refractionAmount / sf
-    val scaledRadii = FloatArray(radii.size) { radii[it] / sf }
-
-    runtimeShaderEffect(
-        key = key,
-        shaderString = shaderString,
-        uniformShaderName = "content",
-    ) {
-        setFloatUniform("size", scaledSizeW, scaledSizeH)
-        setFloatUniform("offset", -scaledPadding, -scaledPadding)
-        setFloatUniform("cornerRadii", scaledRadii)
-        setFloatUniform("refractionHeight", scaledRefractionHeight)
-        setFloatUniform("refractionAmount", -scaledRefractionAmount)
-        setFloatUniform("depthEffect", if (depthEffect) 1f else 0f)
-        if (dispersionEnabled) {
-            setFloatUniform("chromaticAberration", chromaticAberration)
-        }
-    }
-}
-
-private fun BackdropEffectScope.roundedRectCornerRadii(): FloatArray? {
-    val cornerShape = shape as? CornerBasedShape ?: return null
-    val sizePx = size
-    val maxRadius = sizePx.minDimension / 2f
-    val isLtr = layoutDirection == LayoutDirection.Ltr
-    val topLeft = if (isLtr) {
-        cornerShape.topStart.toPx(sizePx, this)
-    } else {
-        cornerShape.topEnd.toPx(sizePx, this)
-    }
-    val topRight = if (isLtr) {
-        cornerShape.topEnd.toPx(sizePx, this)
-    } else {
-        cornerShape.topStart.toPx(sizePx, this)
-    }
-    val bottomRight = if (isLtr) {
-        cornerShape.bottomEnd.toPx(sizePx, this)
-    } else {
-        cornerShape.bottomStart.toPx(sizePx, this)
-    }
-    val bottomLeft = if (isLtr) {
-        cornerShape.bottomStart.toPx(sizePx, this)
-    } else {
-        cornerShape.bottomEnd.toPx(sizePx, this)
-    }
-    return floatArrayOf(
-        topLeft.fastCoerceAtMost(maxRadius),
-        topRight.fastCoerceAtMost(maxRadius),
-        bottomRight.fastCoerceAtMost(maxRadius),
-        bottomLeft.fastCoerceAtMost(maxRadius),
-    )
-}
-
-private const val ROUNDED_RECT_SDF = """
-float radiusAt(float2 coord, float4 radii) {
-    if (coord.x >= 0.0) {
-        if (coord.y <= 0.0) return radii.y;
-        else return radii.z;
-    } else {
-        if (coord.y <= 0.0) return radii.x;
-        else return radii.w;
-    }
-}
-
-float sdRoundedRect(float2 coord, float2 halfSize, float radius) {
-    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
-    float outside = length(max(cornerCoord, 0.0)) - radius;
-    float inside = min(max(cornerCoord.x, cornerCoord.y), 0.0);
-    return outside + inside;
-}
-
-float2 gradSdRoundedRect(float2 coord, float2 halfSize, float radius) {
-    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
-    if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
-        return sign(coord) * normalize(max(cornerCoord, 0.0));
-    } else {
-        float gradX = step(cornerCoord.y, cornerCoord.x);
-        return sign(coord) * float2(gradX, 1.0 - gradX);
-    }
-}
-"""
-
-private const val ROUNDED_RECT_REFRACTION_SHADER = """
-uniform shader content;
-uniform float2 size;
-uniform float2 offset;
-uniform float4 cornerRadii;
-uniform float refractionHeight;
-uniform float refractionAmount;
-uniform float depthEffect;
-
-$ROUNDED_RECT_SDF
-
-float circleMap(float x) {
-    return 1.0 - sqrt(1.0 - x * x);
-}
-
-half4 main(float2 coord) {
-    float2 halfSize = size * 0.5;
-    float2 centeredCoord = (coord + offset) - halfSize;
-    float radius = radiusAt(centeredCoord, cornerRadii);
-    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
-    if (-sd >= refractionHeight) return content.eval(coord);
-    sd = min(sd, 0.0);
-
-    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
-    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
-    float2 grad = normalize(
-        gradSdRoundedRect(centeredCoord, halfSize, gradRadius) +
-        depthEffect * normalize(centeredCoord)
-    );
-    return content.eval(coord + d * grad);
-}
-"""
-
-private const val ROUNDED_RECT_REFRACTION_WITH_DISPERSION_SHADER = """
-uniform shader content;
-uniform float2 size;
-uniform float2 offset;
-uniform float4 cornerRadii;
-uniform float refractionHeight;
-uniform float refractionAmount;
-uniform float depthEffect;
-uniform float chromaticAberration;
-
-$ROUNDED_RECT_SDF
-
-float circleMap(float x) {
-    return 1.0 - sqrt(1.0 - x * x);
-}
-
-half4 main(float2 coord) {
-    float2 halfSize = size * 0.5;
-    float2 centeredCoord = (coord + offset) - halfSize;
-    float radius = radiusAt(centeredCoord, cornerRadii);
-    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
-    if (-sd >= refractionHeight) return content.eval(coord);
-    sd = min(sd, 0.0);
-
-    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
-    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
-    float2 grad = normalize(
-        gradSdRoundedRect(centeredCoord, halfSize, gradRadius) +
-        depthEffect * normalize(centeredCoord)
-    );
-
-    float2 refractedCoord = coord + d * grad;
-    float dispersionIntensity = chromaticAberration *
-        ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));
-    float2 dispersedCoord = d * grad * dispersionIntensity;
-
-    half4 color = half4(0.0);
-    half4 red = content.eval(refractedCoord + dispersedCoord);
-    color.r += red.r / 3.5;
-    color.a += red.a / 7.0;
-
-    half4 orange = content.eval(refractedCoord + dispersedCoord * (2.0 / 3.0));
-    color.r += orange.r / 3.5;
-    color.g += orange.g / 7.0;
-    color.a += orange.a / 7.0;
-
-    half4 yellow = content.eval(refractedCoord + dispersedCoord * (1.0 / 3.0));
-    color.r += yellow.r / 3.5;
-    color.g += yellow.g / 3.5;
-    color.a += yellow.a / 7.0;
-
-    half4 green = content.eval(refractedCoord);
-    color.g += green.g / 3.5;
-    color.a += green.a / 7.0;
-
-    half4 cyan = content.eval(refractedCoord - dispersedCoord * (1.0 / 3.0));
-    color.g += cyan.g / 3.5;
-    color.b += cyan.b / 3.0;
-    color.a += cyan.a / 7.0;
-
-    half4 blue = content.eval(refractedCoord - dispersedCoord * (2.0 / 3.0));
-    color.b += blue.b / 3.0;
-    color.a += blue.a / 7.0;
-
-    half4 purple = content.eval(refractedCoord - dispersedCoord);
-    color.r += purple.r / 7.0;
-    color.b += purple.b / 3.0;
-    color.a += purple.a / 7.0;
-
-    return color;
-}
-"""

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kyant.backdrop.backdrops.LayerBackdrop
 import com.lladlam.melox.ui.glass.meloXLiquidGlass
-import top.yukonga.miuix.kmp.blur.LayerBackdrop
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -75,15 +75,10 @@ fun MeloXIOSMiniPlayer(
         0f
     }
 
-    // Keep #286 geometry untouched. Fade source chrome over most of the morph.
-    // These values are actual draw alpha below, not a parent graphics layer, so
-    // they remain effective after the chrome is lifted into SharedTransitionScope's overlay.
+    // Keep the #286 shared-player geometry intact. Only the glass renderer changes here.
     val miniChromeAlpha = 1f - smoothStep(expansionProgress, 0.05f, 0.72f)
     val miniSurfaceAlpha = 1f - smoothStep(expansionProgress, 0.04f, 0.42f)
 
-    // The shared bounds itself is rendered in SharedTransitionScope's overlay.
-    // Lift source chrome into the same overlay so it is not abruptly covered by
-    // the growing container. Its visual fade is applied to the child draw content.
     val chromeOverlayModifier =
         if (sharedTransitionScope != null) {
             with(sharedTransitionScope) {
@@ -134,14 +129,14 @@ fun MeloXIOSMiniPlayer(
         val miniShape = RoundedCornerShape(22.dp)
         val dark = isSystemInDarkTheme()
         val glassTint = if (dark) {
-            Color.Black.copy(alpha = 0.12f)
+            Color.Black.copy(alpha = 0.08f)
         } else {
-            Color.White.copy(alpha = 0.16f)
+            Color.White.copy(alpha = 0.10f)
         }
         val fallbackTint = if (dark) {
-            MaterialTheme.colorScheme.surface.copy(alpha = 0.64f)
+            MaterialTheme.colorScheme.surface.copy(alpha = 0.62f)
         } else {
-            Color.White.copy(alpha = 0.66f)
+            Color.White.copy(alpha = 0.64f)
         }
 
         Surface(
@@ -154,22 +149,20 @@ fun MeloXIOSMiniPlayer(
                     tint = glassTint,
                     fallbackTint = fallbackTint,
                     alpha = miniSurfaceAlpha,
-                    // The mini player sits directly over list rows. A 6dp blur left
-                    // 1px dividers recognizable as white horizontal bars. A larger
-                    // sampling blur plus reduced contrast/saturation dissolves those
-                    // high-frequency list edges while still preserving backdrop color.
-                    blurRadius = 14.dp,
-                    refractionHeight = 0.dp,
-                    refractionAmount = 0.dp,
-                    chromaticAberration = 0f,
-                    vibrancySaturation = 1.12f,
-                    vibrancyContrast = 0.90f,
+                    // MiniPlayer needs a little more blur than small buttons because it sits
+                    // directly over list dividers. This still samples the single root backdrop.
+                    blurRadius = 12.dp,
+                    refractionHeight = 10.dp,
+                    refractionAmount = 12.dp,
+                    enableLens = true,
+                    highlightAlpha = 0.12f,
+                    shadowAlpha = 0.08f,
                 ),
             shape = miniShape,
             color = Color.Transparent,
             border = null,
             tonalElevation = 0.dp,
-            shadowElevation = (2f * miniSurfaceAlpha).dp,
+            shadowElevation = 0.dp,
         ) {}
 
         Row(

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
     id("com.android.application") version "9.3.0" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
 }


### PR DESCRIPTION
将 MeloX Android 的底部玻璃系统从 Miuix 迁移到 Kyant0/AndroidLiquidGlass 2.0.0，并重构底栏结构。

主要目标：
- 全 App 只记录一个 LayerBackdrop，Tab、Search、MiniPlayer 共同采样；
- 移除 Miuix 与自维护 RuntimeShader/lens；
- 底栏拆分为独立 MeloXBottomChrome；
- Search 圆形按钮直接使用 AndroidLiquidGlass，不再走 Miuix CircleShape fallback；
- MiniPlayer 保留现有 shared transition 几何与 chrome fade，仅替换玻璃渲染；
- 不使用 combined/隐藏 backdrop，控制 GPU 与录制层开销。

此 PR 先用于 CI 验证，CI 通过并检查 API 后再合并。