### PR TITLE
Restore the v5 liquid-glass baseline

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     // ui/glass are adapted from the project's official LiquidButton and
     // LiquidBottomTabs examples while preserving MeloX's iOS geometry.
     implementation("io.github.kyant0:backdrop:2.0.0")
+    implementation("io.github.kyant0:shapes:1.2.0")
 
     implementation("androidx.media3:media3-common:1.10.1")
     implementation("androidx.media3:media3-datasource:1.10.1")

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/library/NeteaseDiscoveryModels.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/library/NeteaseDiscoveryModels.kt
@@ -1,0 +1,8 @@
+package com.lladlam.melox.core.library
+
+import com.lladlam.melox.core.model.SearchSong
+
+data class NeteaseHomeContent(
+    val playlists: List<NeteasePlaylistSummary>,
+    val newSongs: List<SearchSong>,
+)

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/library/NeteaseLibraryCache.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/library/NeteaseLibraryCache.kt
@@ -30,6 +30,35 @@ class NeteaseLibraryCache(context: Context) {
         writeJson(File(directory, "playlist_$playlistId.json"), encodePlaylistDetail(detail))
     }
 
+    suspend fun loadHomeContent(): NeteaseHomeContent? = readJson(
+        File(directory, "home.json"),
+    ) { value ->
+        NeteaseHomeContent(
+            playlists = decodePlaylists(value.optJSONArray("playlists") ?: JSONArray()),
+            newSongs = decodeSongs(value.optJSONArray("newSongs") ?: JSONArray()),
+        )
+    }
+
+    suspend fun saveHomeContent(content: NeteaseHomeContent) {
+        writeJson(
+            File(directory, "home.json"),
+            JSONObject()
+                .put("playlists", encodePlaylists(content.playlists))
+                .put("newSongs", encodeSongs(content.newSongs)),
+        )
+    }
+
+    suspend fun loadExplore(category: String): List<NeteasePlaylistSummary>? = readJson(
+        File(directory, "explore_${category.hashCode()}.json"),
+    ) { value -> decodePlaylists(value.optJSONArray("playlists") ?: JSONArray()) }
+
+    suspend fun saveExplore(category: String, playlists: List<NeteasePlaylistSummary>) {
+        writeJson(
+            File(directory, "explore_${category.hashCode()}.json"),
+            JSONObject().put("playlists", encodePlaylists(playlists)),
+        )
+    }
+
     private suspend fun <T> readJson(file: File, decode: (JSONObject) -> T): T? =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -51,6 +80,8 @@ class NeteaseLibraryCache(context: Context) {
     companion object {
         private val refreshedLibraries = mutableSetOf<Long>()
         private val refreshedPlaylists = mutableSetOf<Long>()
+        private var refreshedHome = false
+        private val refreshedExplore = mutableSetOf<String>()
 
         /** Returns true only for the first automatic refresh in this app process. */
         @Synchronized
@@ -61,6 +92,16 @@ class NeteaseLibraryCache(context: Context) {
         @Synchronized
         fun beginPlaylistColdStartRefresh(playlistId: Long): Boolean =
             refreshedPlaylists.add(playlistId)
+
+        @Synchronized
+        fun beginHomeColdStartRefresh(): Boolean {
+            if (refreshedHome) return false
+            refreshedHome = true
+            return true
+        }
+
+        @Synchronized
+        fun beginExploreColdStartRefresh(category: String): Boolean = refreshedExplore.add(category)
     }
 }
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/library/NeteaseLibraryClient.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/library/NeteaseLibraryClient.kt
@@ -39,6 +39,61 @@ class NeteaseLibraryClient(
     suspend fun playlistDetail(playlistId: Long): NeteasePlaylistDetail =
         withContext(Dispatchers.IO) { playlistDetailBlocking(playlistId) }
 
+    suspend fun homeContent(limit: Int = 12): NeteaseHomeContent = withContext(Dispatchers.IO) {
+        val authenticated = NeteaseSessionStore.containsMusicU(cookieProvider())
+        val playlistsResponse = eapi(
+            uri = "/api/personalized/playlist",
+            data = JSONObject().put("limit", limit).put("total", true).put("n", 1_000),
+            authenticated = authenticated,
+        )
+        val songsResponse = eapi(
+            uri = "/api/personalized/newsong",
+            data = JSONObject().put("type", "recommend").put("limit", limit).put("areaId", 0),
+            authenticated = authenticated,
+        )
+        val songItems = songsResponse.optJSONArray("result") ?: JSONArray()
+        val songs = buildList {
+            for (index in 0 until songItems.length()) {
+                val item = songItems.optJSONObject(index) ?: continue
+                parseSong(item.optJSONObject("song") ?: item)?.let(::add)
+            }
+        }
+        NeteaseHomeContent(
+            playlists = parsePlaylists(playlistsResponse.optJSONArray("result") ?: JSONArray()),
+            newSongs = songs,
+        )
+    }
+
+    suspend fun explorePlaylists(category: String, limit: Int = 50): List<NeteasePlaylistSummary> =
+        withContext(Dispatchers.IO) {
+            val authenticated = NeteaseSessionStore.containsMusicU(cookieProvider())
+            val response = when (category) {
+                "推荐歌单" -> eapi(
+                    "/api/personalized/playlist",
+                    JSONObject().put("limit", limit).put("total", true).put("n", 1_000),
+                    authenticated,
+                )
+                "排行榜" -> eapi("/api/toplist", JSONObject(), authenticated)
+                "精品歌单" -> eapi(
+                    "/api/playlist/highquality/list",
+                    JSONObject().put("cat", "全部").put("limit", limit).put("lasttime", 0).put("total", true),
+                    authenticated,
+                )
+                else -> eapi(
+                    "/api/playlist/list",
+                    JSONObject().put("cat", category).put("order", "hot").put("offset", 0)
+                        .put("limit", limit).put("total", true),
+                    authenticated,
+                )
+            }
+            val values = when (category) {
+                "推荐歌单" -> response.optJSONArray("result")
+                "排行榜" -> response.optJSONArray("list")
+                else -> response.optJSONArray("playlists")
+            } ?: JSONArray()
+            parsePlaylists(values)
+        }
+
     fun userPlaylistsBlocking(userId: Long, limit: Int = 2_000): List<NeteasePlaylistSummary> {
         ensureLoggedIn()
         val response = eapi(
@@ -85,14 +140,14 @@ class NeteaseLibraryClient(
     }
 
     fun playlistDetailBlocking(playlistId: Long): NeteasePlaylistDetail {
-        ensureLoggedIn()
+        val authenticated = NeteaseSessionStore.containsMusicU(cookieProvider())
         val response = eapi(
             uri = "/api/v6/playlist/detail",
             data = JSONObject()
                 .put("id", playlistId)
                 .put("n", 100)
                 .put("s", 8),
-            authenticated = true,
+            authenticated = authenticated,
         )
         val playlist = response.optJSONObject("playlist")
             ?: throw IOException("网易云没有返回歌单详情")
@@ -132,7 +187,7 @@ class NeteaseLibraryClient(
         val response = eapi(
             uri = "/api/v3/song/detail",
             data = JSONObject().put("c", descriptors.toString()),
-            authenticated = true,
+            authenticated = NeteaseSessionStore.containsMusicU(cookieProvider()),
         )
         val songs = response.optJSONArray("songs") ?: JSONArray()
         return buildList {

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -2,6 +2,7 @@ package com.lladlam.melox.ui
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -207,7 +208,7 @@ fun MeloXApp(
                 hasMedia = playbackState.hasMedia,
                 minimized = tabBarMinimized,
                 modifier = Modifier.align(Alignment.BottomCenter),
-                miniPlayer = {
+                miniPlayer = { compactProgress ->
                     AnimatedVisibility(
                         visible = !fullPlayerVisible,
                         enter = EnterTransition.None,
@@ -216,6 +217,7 @@ fun MeloXApp(
                         MeloXIOSMiniPlayer(
                             state = playbackState,
                             onExpand = { showNowPlaying = true },
+                            compactProgress = compactProgress,
                             sharedTransitionScope = sharedScope,
                             animatedVisibilityScope = this,
                         )
@@ -307,7 +309,7 @@ private fun MeloXBottomChrome(
     hasMedia: Boolean,
     minimized: Boolean,
     modifier: Modifier = Modifier,
-    miniPlayer: @Composable () -> Unit,
+    miniPlayer: @Composable (compactProgress: Float) -> Unit,
 ) {
     val rawProgress by animateFloatAsState(
         targetValue = if (minimized) 1f else 0f,
@@ -325,10 +327,10 @@ private fun MeloXBottomChrome(
     val shrinkStage = smoothStep(progress, 0.25f, 0.82f)
     val dropStage = smoothStep(progress, 0.78f, 1.00f)
 
-    val navHeight = lerpDp(66.dp, 58.dp, sizeStage)
-    val searchSize = lerpDp(66.dp, 58.dp, sizeStage)
-    val expandedChromeHeight = if (hasMedia) 137.dp else 72.dp
-    val chromeHeight = lerpDp(expandedChromeHeight, 64.dp, dropStage)
+    val navHeight = lerpDp(56.dp, 52.dp, sizeStage)
+    val searchSize = lerpDp(56.dp, 52.dp, sizeStage)
+    val expandedChromeHeight = if (hasMedia) 119.dp else 62.dp
+    val chromeHeight = lerpDp(expandedChromeHeight, 58.dp, dropStage)
     val labelAlpha = 1f - labelStage
     val expandedLayerAlpha = 1f - smoothStep(progress, 0.43f, 0.72f)
     val compactLayerAlpha = smoothStep(progress, 0.52f, 0.82f)
@@ -344,13 +346,13 @@ private fun MeloXBottomChrome(
                 .fillMaxWidth()
                 .height(chromeHeight),
         ) {
-            val horizontalMargin = 14.dp
-            val compactSize = 58.dp
-            val expandedGap = 9.dp
-            val compactGap = 4.dp
-            val expandedNavWidth = maxWidth - horizontalMargin * 2 - expandedGap - 66.dp
+            val horizontalMargin = 16.dp
+            val compactSize = 52.dp
+            val expandedGap = 8.dp
+            val compactGap = 6.dp
+            val expandedNavWidth = maxWidth - horizontalMargin * 2 - expandedGap - 56.dp
             val navWidth = lerpDp(expandedNavWidth, compactSize, shrinkStage)
-            val navRadius = lerpDp(34.dp, 29.dp, shrinkStage)
+            val navRadius = lerpDp(28.dp, 26.dp, shrinkStage)
             val navShape = RoundedCornerShape(navRadius)
             val primaryTabs = listOf(
                 AppTab.Home to RootGlyph.Home,
@@ -363,11 +365,11 @@ private fun MeloXBottomChrome(
                 (maxWidth - horizontalMargin * 2 - compactSize * 2 - compactGap * 2)
                     .coerceAtLeast(80.dp)
             val compactMiniWrapperWidth =
-                (desiredCompactMiniVisibleWidth + 28.dp).coerceAtMost(maxWidth)
-            val compactMiniWrapperX = horizontalMargin + compactSize + compactGap - 14.dp
+                (desiredCompactMiniVisibleWidth + 32.dp).coerceAtMost(maxWidth)
+            val compactMiniWrapperX = horizontalMargin + compactSize + compactGap - 16.dp
             val miniWrapperWidth = lerpDp(maxWidth, compactMiniWrapperWidth, shrinkStage)
             val miniWrapperX = lerpDp(0.dp, compactMiniWrapperX, shrinkStage)
-            val miniLift = lerpDp(72.dp, 0.dp, shrinkStage)
+            val miniLift = lerpDp(62.dp, 0.dp, shrinkStage)
 
             if (hasMedia) {
                 Box(
@@ -379,7 +381,7 @@ private fun MeloXBottomChrome(
                         )
                         .width(miniWrapperWidth),
                 ) {
-                    miniPlayer()
+                    miniPlayer(progress)
                 }
             }
 
@@ -413,7 +415,41 @@ private fun MeloXBottomChrome(
                 shadowElevation = lerpDp(2.dp, 4.dp, progress),
                 tonalElevation = 0.dp,
             ) {
-                Box(Modifier.fillMaxSize()) {
+                BoxWithConstraints(Modifier.fillMaxSize()) {
+                    val selectedIndex = primaryTabs.indexOfFirst { it.first == selectedTab }
+                    val lensPosition by animateFloatAsState(
+                        targetValue = selectedIndex.coerceAtLeast(0).toFloat(),
+                        animationSpec = spring(
+                            dampingRatio = 0.78f,
+                            stiffness = 360f,
+                            visibilityThreshold = 0.001f,
+                        ),
+                        label = "melox-tab-selection-position",
+                    )
+                    val lensAlpha by animateFloatAsState(
+                        targetValue = if (selectedIndex >= 0 && progress < 0.56f) 1f else 0f,
+                        animationSpec = spring(dampingRatio = 0.86f, stiffness = 440f),
+                        label = "melox-tab-selection-alpha",
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.25f)
+                            .fillMaxHeight()
+                            .padding(4.dp)
+                            .graphicsLayer {
+                                alpha = lensAlpha * expandedLayerAlpha
+                                translationX = lensPosition * constraints.maxWidth / 4f
+                            }
+                            .meloXLiquidTabSelection(
+                                shape = RoundedCornerShape(24.dp),
+                                selected = lensAlpha > 0.001f,
+                                tint = if (dark) {
+                                    Color.White.copy(alpha = 0.18f)
+                                } else {
+                                    Color.White.copy(alpha = 0.32f)
+                                },
+                            ),
+                    )
                     Row(
                         modifier = Modifier
                             .fillMaxSize()
@@ -441,8 +477,12 @@ private fun MeloXBottomChrome(
                         ) {
                             RootGlyphIcon(
                                 glyph = selectedTab.rootGlyph(),
-                                modifier = Modifier.size(27.dp),
-                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(25.dp),
+                                color = if (selectedTab == AppTab.Search) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MeloXAccent
+                                },
                             )
                         }
                     }
@@ -472,7 +512,7 @@ private fun MeloXBottomChrome(
                 Box(contentAlignment = Alignment.Center) {
                     RootGlyphIcon(
                         glyph = RootGlyph.Search,
-                        modifier = Modifier.size(lerpDp(31.dp, 29.dp, sizeStage)),
+                        modifier = Modifier.size(lerpDp(28.dp, 27.dp, sizeStage)),
                         color = if (selectedTab == AppTab.Search) {
                             MeloXAccent
                         } else {
@@ -509,32 +549,29 @@ private fun RowScope.RootTabButton(
     labelAlpha: Float,
     dark: Boolean,
 ) {
-    val foreground = if (selected) MeloXAccent else MaterialTheme.colorScheme.onSurface
-    val selectedBackground = when {
-        !selected -> Color.Transparent
-        dark -> Color.White.copy(alpha = 0.08f)
-        else -> Color.White.copy(alpha = 0.24f)
-    }
+    val foreground by animateColorAsState(
+        targetValue = if (selected) {
+            MeloXAccent
+        } else {
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.78f)
+        },
+        animationSpec = spring(dampingRatio = 0.84f, stiffness = 480f),
+        label = "melox-tab-foreground",
+    )
     Column(
         modifier = Modifier
             .weight(1f)
             .fillMaxHeight()
-            .clip(RoundedCornerShape(28.dp))
-            .meloXLiquidTabSelection(
-                shape = RoundedCornerShape(28.dp),
-                selected = selected,
-                tint = selectedBackground,
-            )
             .padding(horizontal = 4.dp, vertical = 4.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        RootGlyphIcon(glyph = glyph, modifier = Modifier.size(26.dp), color = foreground)
+        RootGlyphIcon(glyph = glyph, modifier = Modifier.size(24.dp), color = foreground)
         Text(
             text = tab.title,
             modifier = Modifier.graphicsLayer { alpha = labelAlpha },
-            fontSize = 10.sp,
-            lineHeight = 12.sp,
+            fontSize = 9.sp,
+            lineHeight = 11.sp,
             fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
             color = foreground,
         )

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -69,6 +69,8 @@ import com.lladlam.melox.ui.account.NeteaseLoginScreen
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import com.lladlam.melox.ui.library.LibraryScreen
+import com.lladlam.melox.ui.discovery.MeloXExploreScreen
+import com.lladlam.melox.ui.discovery.MeloXHomeScreen
 import com.lladlam.melox.ui.glass.LocalMeloXBackdrop
 import com.lladlam.melox.ui.glass.meloXLiquidBottomBar
 import com.lladlam.melox.ui.glass.meloXLiquidButton
@@ -169,14 +171,8 @@ fun MeloXApp(
                 ) {
                     when (selectedTab) {
                         AppTab.Search -> SearchScreen()
-                        AppTab.Home -> MeloXSectionShell(
-                            "首页",
-                            "每日推荐与个性化内容将按 iOS MeloX 结构接入。",
-                        )
-                        AppTab.Explore -> MeloXSectionShell(
-                            "发现",
-                            "推荐、排行榜、精品与分类内容正在迁移。",
-                        )
+                        AppTab.Home -> MeloXHomeScreen()
+                        AppTab.Explore -> MeloXExploreScreen()
                         AppTab.Library -> LibraryScreen(
                             session = neteaseSession,
                             // Back ownership is state-based instead of relying on

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -105,6 +105,7 @@ fun MeloXApp(
     val playbackState = rememberMeloXPlaybackUiState()
     val neteaseSession = rememberNeteaseSessionStore()
     val glassBackdrop = rememberLayerBackdrop()
+    val dynamicGlassEnabled = selectedTab == AppTab.Home || selectedTab == AppTab.Explore
 
     val tabBarMinimizeConnection = remember {
         object : NestedScrollConnection {
@@ -151,7 +152,9 @@ fun MeloXApp(
         scrollAccumulator = 0f
     }
 
-    CompositionLocalProvider(LocalMeloXBackdrop provides glassBackdrop) {
+    CompositionLocalProvider(
+        LocalMeloXBackdrop provides if (dynamicGlassEnabled) glassBackdrop else null,
+    ) {
       Box(modifier = Modifier.fillMaxSize()) {
         SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
             val sharedScope = this
@@ -160,7 +163,10 @@ fun MeloXApp(
                 modifier = Modifier
                     .fillMaxSize()
                     .nestedScroll(tabBarMinimizeConnection)
-                    .layerBackdrop(glassBackdrop),
+                    .then(
+                        if (dynamicGlassEnabled) Modifier.layerBackdrop(glassBackdrop)
+                        else Modifier,
+                    ),
                 contentWindowInsets = WindowInsets(0, 0, 0, 0),
                 containerColor = MaterialTheme.colorScheme.background,
             ) { innerPadding ->
@@ -197,6 +203,7 @@ fun MeloXApp(
 
             MeloXBottomChrome(
                 selectedTab = selectedTab,
+                dynamicGlassEnabled = dynamicGlassEnabled,
                 onSelect = { tab ->
                     tabBarMinimized = false
                     selectedTab = tab
@@ -204,7 +211,7 @@ fun MeloXApp(
                 hasMedia = playbackState.hasMedia,
                 minimized = tabBarMinimized,
                 modifier = Modifier.align(Alignment.BottomCenter),
-                miniPlayer = { compactProgress ->
+                miniPlayer = {
                     AnimatedVisibility(
                         visible = !fullPlayerVisible,
                         enter = EnterTransition.None,
@@ -213,7 +220,8 @@ fun MeloXApp(
                         MeloXIOSMiniPlayer(
                             state = playbackState,
                             onExpand = { showNowPlaying = true },
-                            compactProgress = compactProgress,
+                            inline = tabBarMinimized,
+                            dynamicGlassEnabled = dynamicGlassEnabled,
                             sharedTransitionScope = sharedScope,
                             animatedVisibilityScope = this,
                         )
@@ -301,11 +309,12 @@ private fun MeloXSectionShell(
 @Composable
 private fun MeloXBottomChrome(
     selectedTab: AppTab,
+    dynamicGlassEnabled: Boolean,
     onSelect: (AppTab) -> Unit,
     hasMedia: Boolean,
     minimized: Boolean,
     modifier: Modifier = Modifier,
-    miniPlayer: @Composable (compactProgress: Float) -> Unit,
+    miniPlayer: @Composable () -> Unit,
 ) {
     val rawProgress by animateFloatAsState(
         targetValue = if (minimized) 1f else 0f,
@@ -377,7 +386,7 @@ private fun MeloXBottomChrome(
                         )
                         .width(miniWrapperWidth),
                 ) {
-                    miniPlayer(progress)
+                    miniPlayer()
                 }
             }
 
@@ -408,7 +417,11 @@ private fun MeloXBottomChrome(
                 shape = navShape,
                 color = Color.Transparent,
                 border = null,
-                shadowElevation = lerpDp(2.dp, 4.dp, progress),
+                shadowElevation = if (dynamicGlassEnabled) {
+                    lerpDp(2.dp, 4.dp, progress)
+                } else {
+                    0.dp
+                },
                 tonalElevation = 0.dp,
             ) {
                 BoxWithConstraints(Modifier.fillMaxSize()) {
@@ -502,7 +515,11 @@ private fun MeloXBottomChrome(
                 shape = CircleShape,
                 color = Color.Transparent,
                 border = null,
-                shadowElevation = lerpDp(2.dp, 4.dp, progress),
+                shadowElevation = if (dynamicGlassEnabled) {
+                    lerpDp(2.dp, 4.dp, progress)
+                } else {
+                    0.dp
+                },
                 tonalElevation = 0.dp,
             ) {
                 Box(contentAlignment = Alignment.Center) {

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/discovery/MeloXDiscoveryScreens.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/discovery/MeloXDiscoveryScreens.kt
@@ -1,0 +1,211 @@
+package com.lladlam.melox.ui.discovery
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.lladlam.melox.core.account.NeteaseSessionStore
+import com.lladlam.melox.core.library.NeteaseHomeContent
+import com.lladlam.melox.core.library.NeteaseLibraryCache
+import com.lladlam.melox.core.library.NeteaseLibraryClient
+import com.lladlam.melox.core.library.NeteasePlaylistSummary
+import com.lladlam.melox.core.model.SearchSong
+import com.lladlam.melox.playback.PlaybackCommands
+import kotlinx.coroutines.launch
+
+private val Accent = Color(0xFFFF3147)
+private val Categories = listOf("推荐歌单", "排行榜", "精品歌单", "全部", "华语", "欧美", "流行", "摇滚", "民谣", "电子", "轻音乐", "影视原声", "ACG")
+
+@Composable
+fun MeloXHomeScreen() {
+    val context = LocalContext.current.applicationContext
+    val cache = remember(context) { NeteaseLibraryCache(context) }
+    val client = remember(context) { NeteaseLibraryClient({ NeteaseSessionStore.readCookie(context) }) }
+    val scope = rememberCoroutineScope()
+    var content by remember { mutableStateOf<NeteaseHomeContent?>(null) }
+    var refreshing by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    fun refresh() {
+        if (refreshing) return
+        scope.launch {
+            refreshing = true
+            runCatching { client.homeContent() }
+                .onSuccess { content = it; cache.saveHomeContent(it); error = null }
+                .onFailure { error = it.message ?: "首页加载失败" }
+            refreshing = false
+        }
+    }
+    LaunchedEffect(Unit) {
+        content = cache.loadHomeContent()
+        if (NeteaseLibraryCache.beginHomeColdStartRefresh()) refresh()
+    }
+
+    PullToRefreshBox(isRefreshing = refreshing, onRefresh = ::refresh, modifier = Modifier.fillMaxSize()) {
+        val value = content
+        if (value == null) {
+            EmptyOrLoading(refreshing, error)
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(start = 20.dp, end = 20.dp, top = 70.dp, bottom = 146.dp),
+                verticalArrangement = Arrangement.spacedBy(22.dp),
+            ) {
+                item { LargeTitle("首页") }
+                item { SectionTitle("每日推荐", "下拉可刷新") }
+                item { PlaylistRow(value.playlists, context) }
+                item { SectionTitle("为你推荐", "新歌") }
+                items(value.newSongs, key = { it.id }) { song -> SongRow(song) { PlaybackCommands.playQueue(context, value.newSongs, song.id) } }
+                error?.let { message -> item { Text(message, color = MaterialTheme.colorScheme.error, fontSize = 13.sp) } }
+            }
+        }
+    }
+}
+
+@Composable
+fun MeloXExploreScreen() {
+    val context = LocalContext.current.applicationContext
+    val cache = remember(context) { NeteaseLibraryCache(context) }
+    val client = remember(context) { NeteaseLibraryClient({ NeteaseSessionStore.readCookie(context) }) }
+    val scope = rememberCoroutineScope()
+    var category by remember { mutableStateOf(Categories.first()) }
+    var playlists by remember { mutableStateOf<List<NeteasePlaylistSummary>>(emptyList()) }
+    var refreshing by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    fun refresh() {
+        if (refreshing) return
+        val requested = category
+        scope.launch {
+            refreshing = true
+            runCatching { client.explorePlaylists(requested) }
+                .onSuccess { if (category == requested) playlists = it; cache.saveExplore(requested, it); error = null }
+                .onFailure { error = it.message ?: "发现页加载失败" }
+            refreshing = false
+        }
+    }
+    LaunchedEffect(category) {
+        playlists = cache.loadExplore(category).orEmpty()
+        if (NeteaseLibraryCache.beginExploreColdStartRefresh(category)) refresh()
+    }
+
+    Column(Modifier.fillMaxSize().padding(top = 70.dp)) {
+        LargeTitle("发现", Modifier.padding(horizontal = 20.dp))
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(Categories) { item ->
+                Text(
+                    text = item.removeSuffix("歌单"),
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(if (category == item) Accent else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.06f))
+                        .clickable { category = item }
+                        .padding(horizontal = 14.dp, vertical = 8.dp),
+                    color = if (category == item) Color.White else MaterialTheme.colorScheme.onBackground,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+        PullToRefreshBox(isRefreshing = refreshing, onRefresh = ::refresh, modifier = Modifier.weight(1f)) {
+            if (playlists.isEmpty()) EmptyOrLoading(refreshing, error) else PlaylistGrid(playlists, context)
+        }
+    }
+}
+
+@Composable private fun LargeTitle(text: String, modifier: Modifier = Modifier) = Text(text, modifier, fontSize = 40.sp, lineHeight = 46.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onBackground)
+@Composable private fun SectionTitle(title: String, trailing: String) = Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text(title, fontSize = 25.sp, fontWeight = FontWeight.Bold); Text(trailing, color = MaterialTheme.colorScheme.onBackground.copy(alpha = .42f), fontSize = 13.sp) }
+
+@Composable
+private fun PlaylistRow(values: List<NeteasePlaylistSummary>, context: android.content.Context) {
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        items(values, key = { it.id }) { playlist -> PlaylistCard(playlist, Modifier.width(174.dp)) { playPlaylist(context, playlist) } }
+    }
+}
+
+@Composable
+private fun PlaylistGrid(values: List<NeteasePlaylistSummary>, context: android.content.Context) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 146.dp),
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) { items(values, key = { it.id }) { playlist -> PlaylistCard(playlist, Modifier.fillMaxWidth()) { playPlaylist(context, playlist) } } }
+}
+
+@Composable
+private fun PlaylistCard(value: NeteasePlaylistSummary, modifier: Modifier, onClick: () -> Unit) {
+    Column(modifier.clickable(onClick = onClick)) {
+        AsyncImage(value.coverUrl, null, contentScale = ContentScale.Crop, modifier = Modifier.fillMaxWidth().height(174.dp).clip(RoundedCornerShape(14.dp)))
+        Text(value.name, modifier = Modifier.padding(top = 7.dp), maxLines = 2, overflow = TextOverflow.Ellipsis, fontSize = 15.sp, lineHeight = 19.sp, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+private fun SongRow(song: SearchSong, onClick: () -> Unit) {
+    Row(Modifier.fillMaxWidth().height(58.dp).clickable(onClick = onClick), verticalAlignment = Alignment.CenterVertically) {
+        AsyncImage(song.artworkUrl, null, contentScale = ContentScale.Crop, modifier = Modifier.size(48.dp).clip(RoundedCornerShape(9.dp)))
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(song.name, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.SemiBold)
+            Text(song.artists, maxLines = 1, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onBackground.copy(alpha = .48f), fontSize = 13.sp)
+        }
+    }
+}
+
+@Composable
+private fun EmptyOrLoading(loading: Boolean, error: String?) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        if (loading) CircularProgressIndicator(color = Accent) else Text(error ?: "暂无内容", color = MaterialTheme.colorScheme.onBackground.copy(alpha = .5f))
+    }
+}
+
+private fun playPlaylist(context: android.content.Context, playlist: NeteasePlaylistSummary) {
+    kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Main).launch {
+        runCatching {
+            NeteaseLibraryClient({ NeteaseSessionStore.readCookie(context) }).playlistDetail(playlist.id)
+        }.onSuccess { detail -> detail.songs.firstOrNull()?.let { PlaybackCommands.playQueue(context, detail.songs, it.id) } }
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/discovery/MeloXDiscoveryScreens.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/discovery/MeloXDiscoveryScreens.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXBackdropComponents.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXBackdropComponents.kt
@@ -9,6 +9,8 @@ package com.lladlam.melox.ui.glass
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -20,19 +22,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.lerp
 import com.kyant.backdrop.Backdrop
 import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
-import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.effects.vibrancy
 import com.kyant.backdrop.highlight.Highlight
-import com.kyant.backdrop.shadow.InnerShadow
 import com.kyant.backdrop.shadow.Shadow
+import com.kyant.shapes.Capsule
 import kotlinx.coroutines.launch
 
 /** The screen backdrop sampled by all MeloX liquid controls. */
@@ -52,35 +51,34 @@ fun Modifier.meloXLiquidButton(
     lensRadius: Dp = 12.dp,
     refractionHeight: Dp = 24.dp,
 ): Modifier {
-    val backdrop = LocalMeloXBackdrop.current ?: return this
+    val backdrop = LocalMeloXBackdrop.current
+    if (backdrop == null) {
+        val stableSurface = when {
+            surfaceColor != Color.Unspecified -> surfaceColor.copy(
+                alpha = maxOf(surfaceColor.alpha, 0.46f),
+            )
+            tint == Color.Unspecified -> Color.White.copy(alpha = 0.46f)
+            else -> tint.copy(alpha = maxOf(tint.alpha, 0.42f))
+        }
+        return background(stableSurface, shape)
+            .border(0.75.dp, Color.White.copy(alpha = 0.62f), shape)
+    }
     val scope = rememberCoroutineScope()
     val press = remember { Animatable(0f, 0.001f) }
 
     return this
         .drawBackdrop(
             backdrop = backdrop,
-            shape = { shape },
+            shape = { Capsule() },
             effects = {
                 vibrancy()
                 blur(blurRadius.toPx())
-                lens(lensRadius.toPx(), refractionHeight.toPx())
             },
             highlight = {
-                Highlight.Default.copy(alpha = 0.45f + press.value * 0.55f)
+                Highlight.Plain.copy(alpha = 0.48f + press.value * 0.30f)
             },
             shadow = {
-                Shadow(radius = 4.dp, alpha = 0.16f + press.value * 0.18f)
-            },
-            innerShadow = {
-                InnerShadow(
-                    radius = 5.dp * press.value,
-                    alpha = press.value,
-                )
-            },
-            layerBlock = {
-                val scale = lerp(1f, 1.08f, press.value)
-                scaleX = scale
-                scaleY = scale
+                Shadow(radius = 5.dp, alpha = 0.12f + press.value * 0.06f)
             },
             onDrawSurface = {
                 if (tint != Color.Unspecified) {
@@ -90,11 +88,6 @@ fun Modifier.meloXLiquidButton(
                 if (surfaceColor != Color.Unspecified) drawRect(surfaceColor)
             },
         )
-        .graphicsLayer {
-            val scale = lerp(1f, 0.96f, press.value)
-            scaleX = scale
-            scaleY = scale
-        }
         .pointerInput(enabled) {
             if (!enabled) return@pointerInput
             awaitEachGesture {
@@ -113,17 +106,21 @@ fun Modifier.meloXLiquidBottomBar(
     tint: Color,
     surfaceColor: Color,
 ): Modifier {
-    val backdrop = LocalMeloXBackdrop.current ?: return this
+    val backdrop = LocalMeloXBackdrop.current
+    if (backdrop == null) {
+        val stableSurface = surfaceColor.copy(alpha = maxOf(surfaceColor.alpha, 0.48f))
+        return background(stableSurface, shape)
+            .border(0.75.dp, Color.White.copy(alpha = 0.62f), shape)
+    }
     return drawBackdrop(
         backdrop = backdrop,
-        shape = { shape },
+        shape = { Capsule() },
         effects = {
             vibrancy()
             blur(8.dp.toPx())
-            lens(24.dp.toPx(), 24.dp.toPx())
         },
-        highlight = { Highlight.Ambient },
-        shadow = { Shadow(radius = 6.dp, alpha = 0.20f) },
+        highlight = { Highlight.Plain.copy(alpha = 0.56f) },
+        shadow = { Shadow(radius = 7.dp, alpha = 0.14f) },
         onDrawSurface = {
             drawRect(tint, blendMode = BlendMode.Hue)
             drawRect(surfaceColor)
@@ -139,16 +136,20 @@ fun Modifier.meloXLiquidTabSelection(
     tint: Color,
 ): Modifier {
     if (!selected) return this
-    val backdrop = LocalMeloXBackdrop.current ?: return this
+    val backdrop = LocalMeloXBackdrop.current
+    if (backdrop == null) {
+        return background(tint.copy(alpha = maxOf(tint.alpha, 0.36f)), shape)
+            .border(0.5.dp, Color.White.copy(alpha = 0.58f), shape)
+    }
     return drawBackdrop(
         backdrop = backdrop,
-        shape = { shape },
+        shape = { Capsule() },
         effects = {
-            lens(10.dp.toPx(), 14.dp.toPx(), chromaticAberration = true)
+            vibrancy()
+            blur(2.dp.toPx())
         },
-        highlight = { Highlight.Default },
+        highlight = { Highlight.Plain.copy(alpha = 0.66f) },
         shadow = { Shadow(radius = 3.dp, alpha = 0.16f) },
-        innerShadow = { InnerShadow(radius = 4.dp, alpha = 0.34f) },
         onDrawSurface = { drawRect(tint) },
     )
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/ArtworkDynamicPalette.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/ArtworkDynamicPalette.kt
@@ -219,9 +219,9 @@ internal object ArtworkDynamicPaletteProvider {
     private fun average(colors: List<Color>): Color {
         if (colors.isEmpty()) return ArtworkDynamicPalette.Fallback.average
         return Color(
-            red = colors.map(Color::red).average().toFloat(),
-            green = colors.map(Color::green).average().toFloat(),
-            blue = colors.map(Color::blue).average().toFloat(),
+            red = colors.map { it.red }.average().toFloat(),
+            green = colors.map { it.green }.average().toFloat(),
+            blue = colors.map { it.blue }.average().toFloat(),
             alpha = 1f,
         )
     }

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/ArtworkDynamicPalette.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/ArtworkDynamicPalette.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import kotlin.math.abs
 
 internal data class ArtworkDynamicPalette(
     val cells: List<Color>,
@@ -16,8 +18,12 @@ internal data class ArtworkDynamicPalette(
 ) {
     companion object {
         val Fallback = ArtworkDynamicPalette(
-            cells = List(9) { Color(0xFF5B4B45) },
-            average = Color(0xFF5B4B45),
+            cells = listOf(
+                Color(0xFF101E3D), Color(0xFF2E1A57), Color(0xFF0F3B4D),
+                Color(0xFF38143D), Color(0xFF24476B), Color(0xFF4D1F4D),
+                Color(0xFF0D2E42), Color(0xFF291A4D), Color(0xFF121C33),
+            ),
+            average = Color(0xFF171D32),
         )
     }
 }
@@ -64,10 +70,13 @@ internal object ArtworkDynamicPaletteProvider {
                         decoded.recycle()
                     }
                 }
-            }.getOrElse { ArtworkDynamicPalette.Fallback }
+            }.getOrNull()
 
-            cache[source] = palette
-            palette
+            // Do not cache transient HTTP/decoder failures. A cold start or a
+            // later retry must be able to recover instead of pinning fallback
+            // colors to this artwork URL for the entire process lifetime.
+            if (palette != null) cache[source] = palette
+            palette ?: ArtworkDynamicPalette.Fallback
         }
     }
 
@@ -87,9 +96,10 @@ internal object ArtworkDynamicPaletteProvider {
                 }
             }
         }
+        val displayCells = displayColors(cells)
         return ArtworkDynamicPalette(
-            cells = cells,
-            average = averageColor(bitmap, 0, 0, width, height),
+            cells = displayCells,
+            average = average(displayCells),
         )
     }
 
@@ -130,10 +140,100 @@ internal object ArtworkDynamicPaletteProvider {
         )
     }
 
+    /** Port of ArtworkFlowingLightPalette.displayColorsRGB from MeloX. */
+    private fun displayColors(source: List<Color>): List<Color> {
+        val hsv = source.map(::toHsv)
+        val anchor = hsv.maxByOrNull { it.saturation * (0.38f + it.value * 0.62f) }
+            ?: Hsv(0.62f, 0.72f, 0.48f)
+        val averageValue = hsv.map(Hsv::value).average().toFloat()
+        val chromaticStrength = (anchor.saturation / 0.34f).coerceIn(0f, 1f)
+        val targetValues = floatArrayOf(
+            0.34f, 0.46f, 0.28f,
+            0.27f, 0.50f, 0.36f,
+            0.17f, 0.30f, 0.15f,
+        )
+        val targetSaturations = floatArrayOf(
+            0.76f, 0.64f, 0.82f,
+            0.84f, 0.66f, 0.78f,
+            0.90f, 0.80f, 0.92f,
+        )
+        return hsv.indices.map { index ->
+            val item = hsv[index]
+            val hue = if (item.saturation >= 0.16f && item.value >= 0.08f) {
+                blendedHue(anchor.hue, item.hue, 0.62f)
+            } else {
+                anchor.hue
+            }
+            val artworkSaturation = item.saturation * 0.58f + anchor.saturation * 0.42f
+            val roleSaturation = 0.16f + (targetSaturations[index] - 0.16f) * chromaticStrength
+            val saturation = maxOf(roleSaturation, artworkSaturation).coerceIn(0.12f, 0.96f)
+            val offset = (item.value - averageValue).coerceIn(-0.12f, 0.12f) * 0.24f
+            fromHsv(Hsv(hue, saturation, (targetValues[index] + offset).coerceIn(0.12f, 0.54f)))
+        }
+    }
+
+    private data class Hsv(val hue: Float, val saturation: Float, val value: Float)
+
+    private fun toHsv(color: Color): Hsv {
+        val maximum = maxOf(color.red, color.green, color.blue)
+        val minimum = minOf(color.red, color.green, color.blue)
+        val delta = maximum - minimum
+        val saturation = if (maximum > 0f) delta / maximum else 0f
+        if (delta <= 0.00001f) return Hsv(0f, saturation, maximum)
+        val raw = when (maximum) {
+            color.red -> ((color.green - color.blue) / delta) % 6f
+            color.green -> (color.blue - color.red) / delta + 2f
+            else -> (color.red - color.green) / delta + 4f
+        }
+        val normalized = raw / 6f
+        return Hsv(if (normalized >= 0f) normalized else normalized + 1f, saturation, maximum)
+    }
+
+    private fun fromHsv(hsv: Hsv): Color {
+        val chroma = hsv.value * hsv.saturation
+        val sector = hsv.hue * 6f
+        val secondary = chroma * (1f - abs(sector % 2f - 1f))
+        val offset = hsv.value - chroma
+        val (red, green, blue) = when {
+            sector < 1f -> Triple(chroma, secondary, 0f)
+            sector < 2f -> Triple(secondary, chroma, 0f)
+            sector < 3f -> Triple(0f, chroma, secondary)
+            sector < 4f -> Triple(0f, secondary, chroma)
+            sector < 5f -> Triple(secondary, 0f, chroma)
+            else -> Triple(chroma, 0f, secondary)
+        }
+        return Color(red + offset, green + offset, blue + offset, 1f)
+    }
+
+    private fun blendedHue(source: Float, destination: Float, weight: Float): Float {
+        var delta = destination - source
+        if (delta > 0.5f) delta -= 1f else if (delta < -0.5f) delta += 1f
+        val result = source + delta * weight
+        return when {
+            result < 0f -> result + 1f
+            result >= 1f -> result - 1f
+            else -> result
+        }
+    }
+
+    private fun average(colors: List<Color>): Color {
+        if (colors.isEmpty()) return ArtworkDynamicPalette.Fallback.average
+        return Color(
+            red = colors.map(Color::red).average().toFloat(),
+            green = colors.map(Color::green).average().toFloat(),
+            blue = colors.map(Color::blue).average().toFloat(),
+            alpha = 1f,
+        )
+    }
+
     private fun optimizedArtworkUrl(source: String): String {
         val uri = runCatching { URI(source) }.getOrNull() ?: return source
         if (uri.host?.endsWith(".music.126.net") != true) return source
-        val separator = if (source.contains('?')) '&' else '?'
-        return if (source.contains("param=")) source else "$source${separator}param=160y160"
+        return source.toHttpUrlOrNull()
+            ?.newBuilder()
+            ?.setQueryParameter("param", "160y160")
+            ?.build()
+            ?.toString()
+            ?: source
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
@@ -45,6 +45,7 @@ import com.lladlam.melox.core.lyrics.LyricLine
 import com.lladlam.melox.core.lyrics.LyricsDocument
 import com.lladlam.melox.core.network.NeteaseSearchClient
 import kotlinx.coroutines.delay
+import kotlin.math.abs
 
 private const val LYRIC_FRAME_DELAY_MS = 16L
 private const val FOCUS_COLOR_DURATION_MS = 120
@@ -157,6 +158,7 @@ fun MeloXIOSLyricsPanel(
                             line = line,
                             positionMs = renderedPositionMs,
                             active = index == highlightedIndex,
+                            distanceFromFocus = highlightedIndex?.let { abs(index - it) } ?: 0,
                             onClick = { state.seekTo(line.timeMs) },
                         )
                     }
@@ -171,6 +173,7 @@ private fun MeloXAnimatedLyricLine(
     line: LyricLine,
     positionMs: Long,
     active: Boolean,
+    distanceFromFocus: Int,
     onClick: () -> Unit,
 ) {
     // MeloX keeps focus color and focus geometry as separate transitions. The iOS
@@ -193,6 +196,30 @@ private fun MeloXAnimatedLyricLine(
         ),
         label = "lyric-focus-scale-${line.timeMs}",
     )
+    val distanceAlpha by animateFloatAsState(
+        targetValue = when (distanceFromFocus) {
+            0 -> 1f
+            1 -> 0.72f
+            2 -> 0.52f
+            3 -> 0.38f
+            else -> 0.28f
+        },
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = 360f,
+            visibilityThreshold = 0.001f,
+        ),
+        label = "lyric-distance-alpha-${line.timeMs}",
+    )
+    val focusLift by animateFloatAsState(
+        targetValue = if (active) -5f else 0f,
+        animationSpec = spring(
+            dampingRatio = 0.82f,
+            stiffness = 280f,
+            visibilityThreshold = 0.05f,
+        ),
+        label = "lyric-focus-lift-${line.timeMs}",
+    )
 
     // Reserve the promoted/current-line layout size for every item and only scale
     // its rendered layer. This mirrors MeloX's promotedLayoutScale idea and, most
@@ -205,6 +232,8 @@ private fun MeloXAnimatedLyricLine(
             .graphicsLayer {
                 scaleX = visualScale
                 scaleY = visualScale
+                alpha = distanceAlpha
+                translationY = focusLift
                 transformOrigin = TransformOrigin(0f, 0.5f)
             }
             .clickable(onClick = onClick)

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
@@ -134,7 +134,6 @@ fun MeloXIOSMiniPlayer(
         val compact = compactProgress.coerceIn(0f, 1f)
         val miniShape = RoundedCornerShape(25.dp)
         val artworkSize = lerpDp(40.dp, 30.dp, compact)
-        val metadataAlpha = 1f - smoothStep(compact, 0.42f, 0.92f)
         val artistAlpha = 1f - smoothStep(compact, 0.04f, 0.52f)
         val nextAlpha = 1f - smoothStep(compact, 0.08f, 0.68f)
         val dark = isSystemInDarkTheme()
@@ -216,7 +215,7 @@ fun MeloXIOSMiniPlayer(
                         softWrap = false,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurface.copy(
-                            alpha = miniChromeAlpha * metadataAlpha,
+                            alpha = miniChromeAlpha,
                         ),
                     )
                     Text(

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
@@ -49,7 +49,8 @@ import com.lladlam.melox.ui.glass.meloXLiquidBottomBar
 fun MeloXIOSMiniPlayer(
     state: MeloXPlaybackUiState,
     onExpand: () -> Unit,
-    compactProgress: Float = 0f,
+    inline: Boolean = false,
+    dynamicGlassEnabled: Boolean = true,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -131,11 +132,7 @@ fun MeloXIOSMiniPlayer(
                 )
             },
     ) {
-        val compact = compactProgress.coerceIn(0f, 1f)
         val miniShape = RoundedCornerShape(25.dp)
-        val artworkSize = lerpDp(40.dp, 30.dp, compact)
-        val artistAlpha = 1f - smoothStep(compact, 0.04f, 0.52f)
-        val nextAlpha = 1f - smoothStep(compact, 0.08f, 0.68f)
         val dark = isSystemInDarkTheme()
         val glassTint = if (dark) {
             Color.Black.copy(alpha = 0.12f)
@@ -162,7 +159,7 @@ fun MeloXIOSMiniPlayer(
             color = Color.Transparent,
             border = null,
             tonalElevation = 0.dp,
-            shadowElevation = (2f * miniSurfaceAlpha).dp,
+            shadowElevation = if (dynamicGlassEnabled) (2f * miniSurfaceAlpha).dp else 0.dp,
         ) {}
 
         Row(
@@ -197,8 +194,8 @@ fun MeloXIOSMiniPlayer(
                 Artwork(
                     url = state.artworkUrl,
                     modifier = sharedArtworkModifier
-                        .size(artworkSize)
-                        .clip(RoundedCornerShape(lerpDp(9.dp, 7.dp, compact))),
+                        .size(if (inline) 30.dp else 40.dp)
+                        .clip(RoundedCornerShape(if (inline) 7.dp else 9.dp)),
                 )
 
                 Column(
@@ -218,17 +215,19 @@ fun MeloXIOSMiniPlayer(
                             alpha = miniChromeAlpha,
                         ),
                     )
-                    Text(
-                        text = state.artist,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        fontSize = 12.sp,
-                        lineHeight = 15.sp,
-                        softWrap = false,
-                        color = MaterialTheme.colorScheme.onSurface.copy(
-                            alpha = 0.54f * miniChromeAlpha * artistAlpha,
-                        ),
-                    )
+                    if (!inline) {
+                        Text(
+                            text = state.artist,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            fontSize = 12.sp,
+                            lineHeight = 15.sp,
+                            softWrap = false,
+                            color = MaterialTheme.colorScheme.onSurface.copy(
+                                alpha = 0.54f * miniChromeAlpha,
+                            ),
+                        )
+                    }
                 }
             }
 
@@ -237,15 +236,17 @@ fun MeloXIOSMiniPlayer(
                 enabled = true,
                 onClick = state::togglePlayPause,
                 modifier = chromeOverlayModifier,
-                visualAlpha = miniChromeAlpha * nextAlpha,
-            )
-            MiniVectorButton(
-                kind = MiniGlyph.Forward,
-                enabled = state.hasNext || state.repeatMode != 0,
-                onClick = state::next,
-                modifier = chromeOverlayModifier,
                 visualAlpha = miniChromeAlpha,
             )
+            if (!inline) {
+                MiniVectorButton(
+                    kind = MiniGlyph.Forward,
+                    enabled = state.hasNext || state.repeatMode != 0,
+                    onClick = state::next,
+                    modifier = chromeOverlayModifier,
+                    visualAlpha = miniChromeAlpha,
+                )
+            }
         }
     }
 }
@@ -325,6 +326,3 @@ private fun smoothStep(value: Float, start: Float, end: Float): Float {
     val t = ((value - start) / (end - start)).coerceIn(0f, 1f)
     return t * t * (3f - 2f * t)
 }
-
-private fun lerpDp(start: androidx.compose.ui.unit.Dp, end: androidx.compose.ui.unit.Dp, progress: Float) =
-    (start.value + (end.value - start.value) * progress.coerceIn(0f, 1f)).dp

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
@@ -43,13 +43,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lladlam.melox.ui.glass.meloXLiquidBottomBar
-import com.lladlam.melox.ui.glass.meloXLiquidButton
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun MeloXIOSMiniPlayer(
     state: MeloXPlaybackUiState,
     onExpand: () -> Unit,
+    compactProgress: Float = 0f,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -115,7 +115,7 @@ fun MeloXIOSMiniPlayer(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 14.dp, vertical = 3.dp)
+            .padding(horizontal = 16.dp, vertical = 3.dp)
             .pointerInput(state.mediaId) {
                 detectHorizontalDragGestures(
                     onDragStart = { accumulatedDrag = 0f },
@@ -131,7 +131,12 @@ fun MeloXIOSMiniPlayer(
                 )
             },
     ) {
-        val miniShape = RoundedCornerShape(22.dp)
+        val compact = compactProgress.coerceIn(0f, 1f)
+        val miniShape = RoundedCornerShape(25.dp)
+        val artworkSize = lerpDp(40.dp, 30.dp, compact)
+        val metadataAlpha = 1f - smoothStep(compact, 0.42f, 0.92f)
+        val artistAlpha = 1f - smoothStep(compact, 0.04f, 0.52f)
+        val nextAlpha = 1f - smoothStep(compact, 0.08f, 0.68f)
         val dark = isSystemInDarkTheme()
         val glassTint = if (dark) {
             Color.Black.copy(alpha = 0.12f)
@@ -147,7 +152,7 @@ fun MeloXIOSMiniPlayer(
         Surface(
             modifier = sharedContainerModifier
                 .fillMaxWidth()
-                .height(58.dp)
+                .height(50.dp)
                 .graphicsLayer { alpha = miniSurfaceAlpha }
                 .meloXLiquidBottomBar(
                     shape = miniShape,
@@ -164,8 +169,8 @@ fun MeloXIOSMiniPlayer(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(58.dp)
-                .padding(start = 9.dp, end = 8.dp, top = 7.dp, bottom = 7.dp),
+                .height(50.dp)
+                .padding(start = 7.dp, end = 7.dp, top = 5.dp, bottom = 5.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -193,8 +198,8 @@ fun MeloXIOSMiniPlayer(
                 Artwork(
                     url = state.artworkUrl,
                     modifier = sharedArtworkModifier
-                        .size(44.dp)
-                        .clip(RoundedCornerShape(10.dp)),
+                        .size(artworkSize)
+                        .clip(RoundedCornerShape(lerpDp(9.dp, 7.dp, compact))),
                 )
 
                 Column(
@@ -211,7 +216,7 @@ fun MeloXIOSMiniPlayer(
                         softWrap = false,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurface.copy(
-                            alpha = miniChromeAlpha,
+                            alpha = miniChromeAlpha * metadataAlpha,
                         ),
                     )
                     Text(
@@ -222,7 +227,7 @@ fun MeloXIOSMiniPlayer(
                         lineHeight = 15.sp,
                         softWrap = false,
                         color = MaterialTheme.colorScheme.onSurface.copy(
-                            alpha = 0.54f * miniChromeAlpha,
+                            alpha = 0.54f * miniChromeAlpha * artistAlpha,
                         ),
                     )
                 }
@@ -233,7 +238,7 @@ fun MeloXIOSMiniPlayer(
                 enabled = true,
                 onClick = state::togglePlayPause,
                 modifier = chromeOverlayModifier,
-                visualAlpha = miniChromeAlpha,
+                visualAlpha = miniChromeAlpha * nextAlpha,
             )
             MiniVectorButton(
                 kind = MiniGlyph.Forward,
@@ -264,13 +269,6 @@ private fun MiniVectorButton(
         modifier = modifier
             .size(36.dp)
             .clip(CircleShape)
-            .meloXLiquidButton(
-                shape = CircleShape,
-                enabled = enabled && visualAlpha > 0.05f,
-                surfaceColor = Color.White.copy(alpha = 0.035f * visualAlpha),
-                lensRadius = 8.dp,
-                refractionHeight = 12.dp,
-            )
             .clickable(
                 enabled = enabled && visualAlpha > 0.05f,
                 onClick = onClick,
@@ -328,3 +326,6 @@ private fun smoothStep(value: Float, start: Float, end: Float): Float {
     val t = ((value - start) / (end - start)).coerceIn(0f, 1f)
     return t * t * (3f - 2f * t)
 }
+
+private fun lerpDp(start: androidx.compose.ui.unit.Dp, end: androidx.compose.ui.unit.Dp, progress: Float) =
+    (start.value + (end.value - start.value) * progress.coerceIn(0f, 1f)).dp

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
@@ -7,10 +7,15 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -24,18 +29,25 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -46,6 +58,10 @@ fun MeloXIOSNowPlayingSharedHost(
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     var page by remember(state.mediaId) { mutableStateOf(MeloXNowPlayingPage.Artwork) }
+    val dragOffset = remember(state.mediaId) { Animatable(0f) }
+    val scope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    var committingDismiss by remember(state.mediaId) { mutableStateOf(false) }
 
     val expansionProgress by animatedVisibilityScope.transition.animateFloat(
         transitionSpec = {
@@ -66,6 +82,21 @@ fun MeloXIOSNowPlayingSharedHost(
     val fullPlayerAlpha = smoothStep(expansionProgress, 0.62f, 0.96f)
     val cornerRadius = (22f * (1f - smoothStep(expansionProgress, 0.00f, 0.94f))).dp
 
+    LaunchedEffect(expansionProgress) {
+        if (expansionProgress <= 0.01f) {
+            dragOffset.snapTo(0f)
+            committingDismiss = false
+        }
+    }
+
+    val dragState = rememberDraggableState { delta ->
+        if (!committingDismiss) {
+            scope.launch(start = CoroutineStart.UNDISPATCHED) {
+                dragOffset.snapTo((dragOffset.value + delta).coerceAtLeast(0f))
+            }
+        }
+    }
+
     val sharedContainerModifier = with(sharedTransitionScope) {
         Modifier.sharedBounds(
             sharedContentState = rememberSharedContentState(
@@ -82,11 +113,58 @@ fun MeloXIOSNowPlayingSharedHost(
         )
     }
 
-    Box(
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+      val dismissThreshold = with(density) { 132.dp.toPx() }
+      val maxDrag = constraints.maxHeight.toFloat().coerceAtLeast(1f)
+      val dragProgress = (dragOffset.value / maxDrag).coerceIn(0f, 1f)
+      val dragScale = 1f - dragProgress * 0.035f
+
+      Box(
         modifier = sharedContainerModifier
             .fillMaxSize()
-            .clip(RoundedCornerShape(cornerRadius)),
-    ) {
+            .graphicsLayer {
+                translationY = dragOffset.value * fullPlayerAlpha
+                scaleX = dragScale
+                scaleY = dragScale
+                transformOrigin = TransformOrigin(0.5f, 0f)
+            }
+            .clip(
+                RoundedCornerShape(
+                    cornerRadius + (30.dp - cornerRadius) * dragProgress,
+                ),
+            )
+            .draggable(
+                state = dragState,
+                orientation = Orientation.Vertical,
+                enabled = page == MeloXNowPlayingPage.Artwork && expansionProgress >= 0.995f,
+                onDragStopped = { velocity ->
+                    if (dragOffset.value >= dismissThreshold || velocity >= 1350f) {
+                        committingDismiss = true
+                        scope.launch {
+                            dragOffset.animateTo(
+                                targetValue = maxOf(dragOffset.value, maxDrag * 0.24f),
+                                animationSpec = tween(150),
+                            )
+                            onDismiss()
+                        }
+                    } else {
+                        scope.launch {
+                            dragOffset.animateTo(
+                                targetValue = 0f,
+                                initialVelocity = velocity,
+                                animationSpec = spring(
+                                    dampingRatio = 0.82f,
+                                    stiffness = 430f,
+                                ),
+                            )
+                        }
+                    }
+                },
+            ),
+      ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -123,6 +201,7 @@ fun MeloXIOSNowPlayingSharedHost(
             sharedTransitionScope = sharedTransitionScope,
             animatedVisibilityScope = animatedVisibilityScope,
         )
+      }
     }
 }
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingV2.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingV2.kt
@@ -645,12 +645,6 @@ private fun CupertinoPlayPauseButton(state: MeloXPlaybackUiState) {
                 scaleY = scale
             }
             .clip(CircleShape)
-            .meloXLiquidButton(
-                shape = CircleShape,
-                surfaceColor = Color.White.copy(alpha = 0.035f),
-                lensRadius = 12.dp,
-                refractionHeight = 20.dp,
-            )
             .clickable(
                 interactionSource = interaction,
                 indication = null,
@@ -707,12 +701,6 @@ private fun CupertinoTransportButton(
                 scaleY = scale
             }
             .clip(CircleShape)
-            .meloXLiquidButton(
-                shape = CircleShape,
-                surfaceColor = Color.White.copy(alpha = 0.025f),
-                lensRadius = 10.dp,
-                refractionHeight = 18.dp,
-            )
             .clickable(
                 interactionSource = interaction,
                 indication = null,
@@ -910,13 +898,7 @@ private fun CupertinoPageButton(
                 scaleY = s
             }
             .clip(CircleShape)
-            .meloXLiquidButton(
-                shape = CircleShape,
-                enabled = enabled,
-                surfaceColor = Color.White.copy(alpha = 0.035f + backgroundAlpha * 0.42f),
-                lensRadius = if (selected) 11.dp else 8.dp,
-                refractionHeight = if (selected) 18.dp else 12.dp,
-            )
+            .background(Color.White.copy(alpha = backgroundAlpha * 0.16f))
             .clickable(
                 enabled = enabled,
                 interactionSource = interaction,

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingV2.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingV2.kt
@@ -87,6 +87,7 @@ fun MeloXIOSNowPlayingV2(
     drawBackdrop: Boolean = true,
     drawArtwork: Boolean = true,
 ) {
+    var showActions by remember(state.mediaId) { mutableStateOf(false) }
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -121,6 +122,7 @@ fun MeloXIOSNowPlayingV2(
                     MeloXNowPlayingPage.Artwork -> MeloXArtworkPageV3(
                         state = state,
                         drawArtwork = drawArtwork,
+                        onMore = { showActions = true },
                     )
                     MeloXNowPlayingPage.Lyrics -> MeloXIOSLyricsPanel(
                         state = state,
@@ -147,6 +149,12 @@ fun MeloXIOSNowPlayingV2(
                 },
             )
         }
+
+        MeloXNowPlayingActionsSheet(
+            state = state,
+            visible = showActions,
+            onDismiss = { showActions = false },
+        )
     }
 }
 
@@ -261,6 +269,7 @@ private fun pageTransform(
 private fun MeloXArtworkPageV3(
     state: MeloXPlaybackUiState,
     drawArtwork: Boolean,
+    onMore: () -> Unit,
 ) {
     val artworkScale by animateFloatAsState(
         targetValue = if (state.isPlaying) 1f else 0.74f,
@@ -336,25 +345,44 @@ private fun MeloXArtworkPageV3(
 
             Spacer(Modifier.height(20.dp))
 
-            Column(modifier = Modifier.fillMaxWidth()) {
-                Text(
-                    text = state.title.ifBlank { "正在播放" },
-                    color = Color.White,
-                    fontSize = 20.sp,
-                    lineHeight = 24.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = state.artist,
-                    color = Color.White.copy(alpha = 0.64f),
-                    fontSize = 20.sp,
-                    lineHeight = 24.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(top = 2.dp),
-                )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = state.title.ifBlank { "正在播放" },
+                        color = Color.White,
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state.artist,
+                        color = Color.White.copy(alpha = 0.64f),
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onMore),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "•••",
+                        color = Color.White,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
             }
 
             Spacer(Modifier.height(8.dp))

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXNowPlayingActionsSheet.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXNowPlayingActionsSheet.kt
@@ -1,0 +1,196 @@
+package com.lladlam.melox.ui.player
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.lladlam.melox.ui.glass.meloXLiquidButton
+import java.net.URLEncoder
+
+private enum class ActionPage { Main, Sleep }
+
+@Composable
+fun MeloXNowPlayingActionsSheet(
+    state: MeloXPlaybackUiState,
+    visible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    if (!visible) return
+    val context = LocalContext.current
+    var page by remember(state.mediaId) { mutableStateOf(ActionPage.Main) }
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(indication = null, interactionSource = null, onClick = onDismiss)
+                .padding(horizontal = 18.dp)
+                .navigationBarsPadding(),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 18.dp)
+                    .meloXLiquidButton(
+                        shape = RoundedCornerShape(30.dp),
+                        tint = Color.White.copy(alpha = 0.10f),
+                        surfaceColor = Color.Black.copy(alpha = 0.28f),
+                        blurRadius = 12.dp,
+                        lensRadius = 26.dp,
+                        refractionHeight = 26.dp,
+                    )
+                    .clickable(enabled = false) {},
+                color = Color.Transparent,
+                shape = RoundedCornerShape(30.dp),
+            ) {
+                AnimatedContent(
+                    targetState = page,
+                    transitionSpec = {
+                        (fadeIn(spring(stiffness = 520f)) + scaleIn(initialScale = 0.96f)) togetherWith
+                            (fadeOut(spring(stiffness = 620f)) + scaleOut(targetScale = 0.96f))
+                    },
+                    label = "now-playing-actions-page",
+                ) { selected ->
+                    Column(Modifier.padding(horizontal = 18.dp, vertical = 20.dp)) {
+                        when (selected) {
+                            ActionPage.Main -> MainActions(state, context, onDismiss) { page = ActionPage.Sleep }
+                            ActionPage.Sleep -> SleepActions(state, onDismiss) { page = ActionPage.Main }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MainActions(
+    state: MeloXPlaybackUiState,
+    context: Context,
+    onDismiss: () -> Unit,
+    onSleep: () -> Unit,
+) {
+    ActionHeader(state, "歌曲操作")
+    ActionItem("定时关闭", "◷", onSleep)
+    ActionItem("添加到播放队列", "+") { state.addCurrentToQueue(); onDismiss() }
+    ActionItem("添加到歌单", "≡") { openSong(context, state); onDismiss() }
+    ActionItem("收藏 / 取消收藏", "♥") { openSong(context, state); onDismiss() }
+    ActionItem("分享", "↗") { shareSong(context, state); onDismiss() }
+    ActionItem("评论", "◌") { openSong(context, state, "#comment-box"); onDismiss() }
+    ActionItem("歌曲百科", "i") { openSong(context, state); onDismiss() }
+    ActionItem("一起听", "◎") { openSong(context, state); onDismiss() }
+    ActionItem("前往专辑", "▣") { openSearch(context, state.album, 10); onDismiss() }
+    ActionItem("前往歌手", "♬") { openSearch(context, state.artist, 100); onDismiss() }
+}
+
+@Composable
+private fun SleepActions(state: MeloXPlaybackUiState, onDismiss: () -> Unit, onBack: () -> Unit) {
+    ActionHeader(state, "定时关闭")
+    listOf(15, 30, 45, 60).forEach { minutes ->
+        ActionItem("$minutes 分钟后", "◷") { state.setSleepTimer(minutes); onDismiss() }
+    }
+    if (state.sleepTimerEndRealtimeMs > 0L) {
+        ActionItem("取消定时", "×") { state.cancelSleepTimer(); onDismiss() }
+    }
+    ActionItem("返回", "‹", onBack)
+}
+
+@Composable
+private fun ActionHeader(state: MeloXPlaybackUiState, title: String) {
+    Text(title, color = Color.White.copy(alpha = 0.58f), fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+    Text(
+        text = state.title.ifBlank { "正在播放" },
+        color = Color.White,
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.padding(top = 3.dp, bottom = 12.dp),
+    )
+}
+
+@Composable
+private fun ActionItem(title: String, symbol: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) {
+            Text(symbol, color = Color.White, fontSize = 19.sp, fontWeight = FontWeight.SemiBold)
+        }
+        Text(title, color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+private fun shareSong(context: Context, state: MeloXPlaybackUiState) {
+    val url = "https://music.163.com/song?id=${state.mediaId.orEmpty()}"
+    context.startActivity(
+        Intent.createChooser(
+            Intent(Intent.ACTION_SEND).setType("text/plain")
+                .putExtra(Intent.EXTRA_TEXT, "${state.title} - ${state.artist}\n$url"),
+            "分享歌曲",
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+    )
+}
+
+private fun openSong(context: Context, state: MeloXPlaybackUiState, suffix: String = "") {
+    openUrl(context, "https://music.163.com/#/song?id=${state.mediaId.orEmpty()}$suffix")
+}
+
+private fun openSearch(context: Context, query: String, type: Int) {
+    if (query.isBlank()) return
+    val encoded = URLEncoder.encode(query, Charsets.UTF_8.name())
+    openUrl(context, "https://music.163.com/#/search/m/?s=$encoded&type=$type")
+}
+
+private fun openUrl(context: Context, url: String) {
+    runCatching {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXPlayerUi.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXPlayerUi.kt
@@ -84,6 +84,8 @@ data class MeloXQueueEntry(
 @Stable
 class MeloXPlaybackUiState internal constructor() {
     private var controller: MediaController? = null
+    private val sleepTimerHandler = Handler(Looper.getMainLooper())
+    private var sleepTimerRunnable: Runnable? = null
 
     var mediaId by mutableStateOf<String?>(null)
         private set
@@ -115,6 +117,8 @@ class MeloXPlaybackUiState internal constructor() {
         private set
     var volume by mutableFloatStateOf(1f)
         private set
+    var sleepTimerEndRealtimeMs by mutableLongStateOf(0L)
+        private set
 
     val hasMedia: Boolean
         get() = mediaId != null
@@ -143,6 +147,7 @@ class MeloXPlaybackUiState internal constructor() {
         controller?.removeListener(listener)
         controller?.release()
         controller = null
+        cancelSleepTimer()
     }
 
     internal fun refresh() {
@@ -232,6 +237,33 @@ class MeloXPlaybackUiState internal constructor() {
             player.volume = value.coerceIn(0f, 1f)
             volume = player.volume
         }
+    }
+
+    fun addCurrentToQueue() {
+        val player = controller ?: return
+        val item = player.currentMediaItem ?: return
+        player.addMediaItem(item)
+        refresh()
+    }
+
+    fun setSleepTimer(minutes: Int) {
+        cancelSleepTimer()
+        if (minutes <= 0) return
+        val delayMillis = minutes * 60_000L
+        sleepTimerEndRealtimeMs = android.os.SystemClock.elapsedRealtime() + delayMillis
+        val runnable = Runnable {
+            controller?.pause()
+            sleepTimerEndRealtimeMs = 0L
+            sleepTimerRunnable = null
+        }
+        sleepTimerRunnable = runnable
+        sleepTimerHandler.postDelayed(runnable, delayMillis)
+    }
+
+    fun cancelSleepTimer() {
+        sleepTimerRunnable?.let(sleepTimerHandler::removeCallbacks)
+        sleepTimerRunnable = null
+        sleepTimerEndRealtimeMs = 0L
     }
 }
 


### PR DESCRIPTION
## What changed

- restores the liquid-glass rendering strategy verified from the uploaded v5 APK
- enables the live `LayerBackdrop` only on Home and Explore
- restores stable material fallbacks for Library, Settings, Search, and controls without a backdrop
- removes the unstable lens/refraction chain used after v5
- restores the compact inline mini-player behavior when the Dock collapses

## Why

The uploaded `MeloX-Dock-PlayerGesture-v5-debug.apk` (SHA-256 `023f2f331a67cd3cbd108dd20626a443d7fc6d61287cb702b33d5cb4d2e12a79`) is the closest known-good liquid-glass rendering reference. The original Kotlin snapshot was not committed, so these differences were reconstructed from its Kotlin metadata and decompiled app classes onto the last pre-regression source boundary.

## Validation

- `git diff --check` passes locally
- uploaded APK hash was verified
- key Kotlin behavior was cross-checked against the APK bytecode
- local Android build could not resolve AGP because this runtime cannot access Google Maven; GitHub Actions is the authoritative build check
