### PR TITLE
Fix liquid glass backdrop isolation and Dock blur

### DIFF
--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -47,9 +47,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
@@ -62,11 +64,13 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lladlam.melox.core.account.rememberNeteaseSessionStore
 import com.lladlam.melox.ui.account.NeteaseLoginScreen
 import com.kyant.backdrop.backdrops.layerBackdrop
+import com.kyant.backdrop.backdrops.rememberCanvasBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import com.lladlam.melox.ui.library.LibraryScreen
 import com.lladlam.melox.ui.discovery.MeloXExploreScreen
@@ -80,6 +84,7 @@ import com.lladlam.melox.ui.player.MeloXIOSNowPlayingSharedHost
 import com.lladlam.melox.ui.player.rememberMeloXPlaybackUiState
 import com.lladlam.melox.ui.search.SearchScreen
 import com.lladlam.melox.ui.settings.SettingsScreen
+import kotlin.math.roundToInt
 
 enum class AppTab(val title: String) {
     Home("首页"),
@@ -104,8 +109,24 @@ fun MeloXApp(
     var scrollAccumulator by remember { mutableFloatStateOf(0f) }
     val playbackState = rememberMeloXPlaybackUiState()
     val neteaseSession = rememberNeteaseSessionStore()
-    val glassBackdrop = rememberLayerBackdrop()
-    val dynamicGlassEnabled = selectedTab == AppTab.Home || selectedTab == AppTab.Explore
+    val darkGlass = isSystemInDarkTheme()
+    // Page controls use a stable, non-recursive scene. The Dock samples the
+    // live page layer separately below. Keeping both scenes isolated prevents
+    // descendants from reading a LayerBackdrop while that same layer records.
+    val screenControlBackdrop = rememberCanvasBackdrop {
+        drawRect(
+            brush = Brush.linearGradient(
+                colors = if (darkGlass) {
+                    listOf(Color(0xFF31323A), Color(0xFF111219))
+                } else {
+                    listOf(Color(0xFFFDFDFE), Color(0xFFD9DCE2))
+                },
+                start = Offset.Zero,
+                end = Offset(size.width, size.height),
+            ),
+        )
+    }
+    val bottomChromeBackdrop = rememberLayerBackdrop()
 
     val tabBarMinimizeConnection = remember {
         object : NestedScrollConnection {
@@ -152,9 +173,7 @@ fun MeloXApp(
         scrollAccumulator = 0f
     }
 
-    CompositionLocalProvider(
-        LocalMeloXBackdrop provides if (dynamicGlassEnabled) glassBackdrop else null,
-    ) {
+    CompositionLocalProvider(LocalMeloXBackdrop provides screenControlBackdrop) {
       Box(modifier = Modifier.fillMaxSize()) {
         SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
             val sharedScope = this
@@ -163,10 +182,7 @@ fun MeloXApp(
                 modifier = Modifier
                     .fillMaxSize()
                     .nestedScroll(tabBarMinimizeConnection)
-                    .then(
-                        if (dynamicGlassEnabled) Modifier.layerBackdrop(glassBackdrop)
-                        else Modifier,
-                    ),
+                    .layerBackdrop(bottomChromeBackdrop),
                 contentWindowInsets = WindowInsets(0, 0, 0, 0),
                 containerColor = MaterialTheme.colorScheme.background,
             ) { innerPadding ->
@@ -201,33 +217,34 @@ fun MeloXApp(
                 }
             }
 
-            MeloXBottomChrome(
-                selectedTab = selectedTab,
-                dynamicGlassEnabled = dynamicGlassEnabled,
-                onSelect = { tab ->
-                    tabBarMinimized = false
-                    selectedTab = tab
-                },
-                hasMedia = playbackState.hasMedia,
-                minimized = tabBarMinimized,
-                modifier = Modifier.align(Alignment.BottomCenter),
-                miniPlayer = {
-                    AnimatedVisibility(
-                        visible = !fullPlayerVisible,
-                        enter = EnterTransition.None,
-                        exit = ExitTransition.None,
-                    ) {
-                        MeloXIOSMiniPlayer(
-                            state = playbackState,
-                            onExpand = { showNowPlaying = true },
-                            inline = tabBarMinimized,
-                            dynamicGlassEnabled = dynamicGlassEnabled,
-                            sharedTransitionScope = sharedScope,
-                            animatedVisibilityScope = this,
-                        )
-                    }
-                },
-            )
+            CompositionLocalProvider(LocalMeloXBackdrop provides bottomChromeBackdrop) {
+                MeloXBottomChrome(
+                    selectedTab = selectedTab,
+                    onSelect = { tab ->
+                        tabBarMinimized = false
+                        selectedTab = tab
+                    },
+                    hasMedia = playbackState.hasMedia,
+                    minimized = tabBarMinimized,
+                    modifier = Modifier.align(Alignment.BottomCenter),
+                    miniPlayer = {
+                        AnimatedVisibility(
+                            visible = !fullPlayerVisible,
+                            enter = EnterTransition.None,
+                            exit = ExitTransition.None,
+                        ) {
+                            MeloXIOSMiniPlayer(
+                                state = playbackState,
+                                onExpand = { showNowPlaying = true },
+                                inline = tabBarMinimized,
+                                dynamicGlassEnabled = true,
+                                sharedTransitionScope = sharedScope,
+                                animatedVisibilityScope = this,
+                            )
+                        }
+                    },
+                )
+            }
 
             if (fullPlayerVisible) {
                 Box(
@@ -309,13 +326,13 @@ private fun MeloXSectionShell(
 @Composable
 private fun MeloXBottomChrome(
     selectedTab: AppTab,
-    dynamicGlassEnabled: Boolean,
     onSelect: (AppTab) -> Unit,
     hasMedia: Boolean,
     minimized: Boolean,
     modifier: Modifier = Modifier,
     miniPlayer: @Composable () -> Unit,
 ) {
+    val tabsBackdrop = rememberLayerBackdrop()
     val rawProgress by animateFloatAsState(
         targetValue = if (minimized) 1f else 0f,
         animationSpec = spring(
@@ -401,7 +418,7 @@ private fun MeloXBottomChrome(
                     .meloXLiquidBottomBar(
                         shape = navShape,
                         tint = bottomLiquidGlassTint(),
-                        surfaceColor = bottomGlassFallbackColor().copy(alpha = 0.42f),
+                        surfaceColor = bottomGlassFallbackColor().copy(alpha = 0.18f),
                     )
                     .pointerInput(progress, selectedTab) {
                         detectTapGestures { tap ->
@@ -417,20 +434,32 @@ private fun MeloXBottomChrome(
                 shape = navShape,
                 color = Color.Transparent,
                 border = null,
-                shadowElevation = if (dynamicGlassEnabled) {
-                    lerpDp(2.dp, 4.dp, progress)
-                } else {
-                    0.dp
-                },
+                shadowElevation = lerpDp(2.dp, 4.dp, progress),
                 tonalElevation = 0.dp,
             ) {
                 BoxWithConstraints(Modifier.fillMaxSize()) {
+                    // Mirror the official LiquidBottomTabs scene graph: record
+                    // an invisible panel layer so the selection can sample the
+                    // combined page + Dock glass instead of raw page pixels.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .alpha(0f)
+                            .layerBackdrop(tabsBackdrop)
+                            .meloXLiquidBottomBar(
+                                shape = navShape,
+                                tint = bottomLiquidGlassTint(),
+                                surfaceColor = bottomGlassFallbackColor().copy(alpha = 0.18f),
+                            ),
+                    )
                     val selectedIndex = primaryTabs.indexOfFirst { it.first == selectedTab }
                     val lensPosition by animateFloatAsState(
                         targetValue = selectedIndex.coerceAtLeast(0).toFloat(),
                         animationSpec = spring(
-                            dampingRatio = 0.78f,
-                            stiffness = 360f,
+                            // No overshoot: the selection glides between tabs
+                            // without the fractional-layer lean seen on device.
+                            dampingRatio = 1f,
+                            stiffness = 460f,
                             visibilityThreshold = 0.001f,
                         ),
                         label = "melox-tab-selection-position",
@@ -444,14 +473,22 @@ private fun MeloXBottomChrome(
                         modifier = Modifier
                             .fillMaxWidth(0.25f)
                             .fillMaxHeight()
+                            .offset {
+                                IntOffset(
+                                    x = (
+                                        lensPosition * constraints.maxWidth / 4f
+                                        ).roundToInt(),
+                                    y = 0,
+                                )
+                            }
                             .padding(4.dp)
                             .graphicsLayer {
                                 alpha = lensAlpha * expandedLayerAlpha
-                                translationX = lensPosition * constraints.maxWidth / 4f
                             }
                             .meloXLiquidTabSelection(
                                 shape = RoundedCornerShape(24.dp),
                                 selected = lensAlpha > 0.001f,
+                                panelBackdrop = tabsBackdrop,
                                 tint = if (dark) {
                                     Color.White.copy(alpha = 0.18f)
                                 } else {
@@ -509,17 +546,13 @@ private fun MeloXBottomChrome(
                         blurRadius = 6.dp,
                         lensRadius = 12.dp,
                         refractionHeight = 18.dp,
-                        surfaceColor = bottomGlassFallbackColor().copy(alpha = 0.32f),
+                        surfaceColor = bottomGlassFallbackColor().copy(alpha = 0.16f),
                     )
                     .clickable { onSelect(AppTab.Search) },
                 shape = CircleShape,
                 color = Color.Transparent,
                 border = null,
-                shadowElevation = if (dynamicGlassEnabled) {
-                    lerpDp(2.dp, 4.dp, progress)
-                } else {
-                    0.dp
-                },
+                shadowElevation = lerpDp(2.dp, 4.dp, progress),
                 tonalElevation = 0.dp,
             ) {
                 Box(contentAlignment = Alignment.Center) {

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXBackdropComponents.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXBackdropComponents.kt
@@ -26,12 +26,14 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.Backdrop
+import com.kyant.backdrop.backdrops.rememberCombinedBackdrop
 import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
+import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.effects.vibrancy
 import com.kyant.backdrop.highlight.Highlight
+import com.kyant.backdrop.shadow.InnerShadow
 import com.kyant.backdrop.shadow.Shadow
-import com.kyant.shapes.Capsule
 import kotlinx.coroutines.launch
 
 /** The screen backdrop sampled by all MeloX liquid controls. */
@@ -69,16 +71,31 @@ fun Modifier.meloXLiquidButton(
     return this
         .drawBackdrop(
             backdrop = backdrop,
-            shape = { Capsule() },
+            shape = { shape },
             effects = {
                 vibrancy()
                 blur(blurRadius.toPx())
+                // AndroidLiquidGlass' official button uses a 12/24dp lens.
+                // Keep the same effect order with a shallower, non-chromatic
+                // lens: full demo refraction produced polygonal artifacts on
+                // the target MediaTek renderer.
+                lens(
+                    (lensRadius * 0.42f).toPx(),
+                    (refractionHeight * 0.32f).toPx(),
+                    chromaticAberration = false,
+                )
             },
             highlight = {
-                Highlight.Plain.copy(alpha = 0.48f + press.value * 0.30f)
+                Highlight.Default.copy(alpha = 0.44f + press.value * 0.36f)
             },
             shadow = {
-                Shadow(radius = 5.dp, alpha = 0.12f + press.value * 0.06f)
+                Shadow(radius = 4.dp, alpha = 0.14f + press.value * 0.08f)
+            },
+            innerShadow = {
+                InnerShadow(
+                    radius = 4.dp * press.value,
+                    alpha = press.value * 0.72f,
+                )
             },
             onDrawSurface = {
                 if (tint != Color.Unspecified) {
@@ -114,13 +131,17 @@ fun Modifier.meloXLiquidBottomBar(
     }
     return drawBackdrop(
         backdrop = backdrop,
-        shape = { Capsule() },
+        shape = { shape },
         effects = {
             vibrancy()
             blur(8.dp.toPx())
+            // Official LiquidBottomTabs uses a 24/24dp lens. A shallow lens
+            // preserves the edge refraction while remaining stable on the
+            // target GPU; blur and vibrancy remain at the official values.
+            lens(3.dp.toPx(), 4.dp.toPx(), chromaticAberration = false)
         },
-        highlight = { Highlight.Plain.copy(alpha = 0.56f) },
-        shadow = { Shadow(radius = 7.dp, alpha = 0.14f) },
+        highlight = { Highlight.Default.copy(alpha = 0.68f) },
+        shadow = { Shadow(radius = 6.dp, alpha = 0.16f) },
         onDrawSurface = {
             drawRect(tint, blendMode = BlendMode.Hue)
             drawRect(surfaceColor)
@@ -134,6 +155,7 @@ fun Modifier.meloXLiquidTabSelection(
     shape: Shape,
     selected: Boolean,
     tint: Color,
+    panelBackdrop: Backdrop? = null,
 ): Modifier {
     if (!selected) return this
     val backdrop = LocalMeloXBackdrop.current
@@ -141,15 +163,26 @@ fun Modifier.meloXLiquidTabSelection(
         return background(tint.copy(alpha = maxOf(tint.alpha, 0.36f)), shape)
             .border(0.5.dp, Color.White.copy(alpha = 0.58f), shape)
     }
+    // Official LiquidBottomTabs records the panel into a second Backdrop and
+    // samples the combined page + panel scene for the moving selection.
+    // Without this, the selected capsule samples page artwork directly and
+    // appears skewed or punched through.
+    val selectionBackdrop = if (panelBackdrop != null) {
+        rememberCombinedBackdrop(backdrop, panelBackdrop)
+    } else {
+        backdrop
+    }
     return drawBackdrop(
-        backdrop = backdrop,
-        shape = { Capsule() },
+        backdrop = selectionBackdrop,
+        shape = { shape },
         effects = {
-            vibrancy()
-            blur(2.dp.toPx())
+            // At rest the official selection has almost no refraction; the
+            // large chromatic lens is only introduced while dragging.
+            lens(0.25.dp.toPx(), 0.5.dp.toPx(), chromaticAberration = false)
         },
-        highlight = { Highlight.Plain.copy(alpha = 0.66f) },
-        shadow = { Shadow(radius = 3.dp, alpha = 0.16f) },
+        highlight = { Highlight.Default.copy(alpha = 0.56f) },
+        shadow = { Shadow(radius = 3.dp, alpha = 0.12f) },
+        innerShadow = { InnerShadow(radius = 3.dp, alpha = 0.18f) },
         onDrawSurface = { drawRect(tint) },
     )
 }


### PR DESCRIPTION
## What changed

- separates page-local controls from the live Dock sampling layer to prevent recursive Backdrop rendering
- enables the live Dock backdrop on Home, Explore, Library, Settings, and Search
- restores each control's requested shape instead of forcing every surface to a capsule
- ports the official LiquidBottomTabs two-layer selection structure with a combined page + panel backdrop
- restores blur, vibrancy, highlight, shadow, and shallow non-chromatic lens effects
- lowers the opaque Dock surface overlay so the sampled blur remains visible
- moves the selected tab with a critically damped integer-offset spring to avoid the skewed/leaning artifact

## Root cause

Home/Explore were the only tabs using a live LayerBackdrop, while Library/Settings/Search fell back to static fills. Page controls and bottom chrome also shared the same recording scene, and the selected tab sampled raw page content rather than a combined Dock scene. The restored V5 helper additionally ignored caller shapes and removed all lens use.

## Compatibility note

The scene graph follows Kyant0/AndroidLiquidGlass's official LiquidButton and LiquidBottomTabs examples. Refraction is intentionally shallower and chromatic aberration is disabled because the target MediaTek device previously showed polygonal shader artifacts at the demo's 24dp lens values.

## Validation

- `git diff --check` passes
- local Gradle cache was repaired, but this environment cannot resolve Android Gradle Plugin 9.3.0 from Google Maven; the PR Android workflow is the authoritative compile check