### PR TITLE
refactor(player): rebuild Now Playing scene and page transitions

### DIFF
--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -7,10 +7,12 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.SeekableTransitionState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.rememberTransition
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -121,7 +123,7 @@ fun MeloXApp(
             playerScope.launch {
                 playerTransitionState.animateTo(
                     targetState = true,
-                    animationSpec = playerFractionSpec(),
+                    animationSpec = playerAutomaticFractionSpec(),
                 )
             }
         }
@@ -130,7 +132,7 @@ fun MeloXApp(
         playerScope.launch {
             playerTransitionState.animateTo(
                 targetState = false,
-                animationSpec = playerFractionSpec(),
+                animationSpec = playerAutomaticFractionSpec(),
             )
         }
     }
@@ -182,9 +184,9 @@ fun MeloXApp(
     LaunchedEffect(openNowPlayingRequest, playbackState.hasMedia) {
         if (openNowPlayingRequest > 0 && playbackState.hasMedia) {
             playerTransitionState.animateTo(
-                    targetState = true,
-                    animationSpec = playerFractionSpec(),
-                )
+                targetState = true,
+                animationSpec = playerAutomaticFractionSpec(),
+            )
         }
     }
 
@@ -309,7 +311,7 @@ fun MeloXApp(
                     onSettleCollapse = { collapse ->
                         playerTransitionState.animateTo(
                             targetState = !collapse,
-                            animationSpec = playerFractionSpec(),
+                            animationSpec = playerGestureSettleSpec(),
                         )
                     },
                     sharedTransitionScope = sharedScope,
@@ -775,10 +777,14 @@ private fun RootGlyphIcon(
     }
 }
 
+private fun playerAutomaticFractionSpec() = tween<Float>(
+    durationMillis = 460,
+    easing = FastOutSlowInEasing,
+)
 
-private fun playerFractionSpec() = spring<Float>(
+private fun playerGestureSettleSpec() = spring<Float>(
     dampingRatio = 1.0f,
-    stiffness = 380f,
+    stiffness = 420f,
     visibilityThreshold = 0.001f,
 )
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
@@ -1,0 +1,410 @@
+package com.lladlam.melox.ui.player
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+
+/**
+ * The portrait Now Playing scene mirrors the upstream iOS page architecture:
+ * artwork details are transient, Lyrics and Queue live as resident layers, the
+ * song header is shared by alternate pages, and the bottom controls never leave
+ * the composition while pages change.
+ *
+ * The actual artwork is intentionally not drawn here. SharedHost owns one
+ * persistent artwork layer so the same image can move between the full artwork
+ * frame, the 72dp song-header frame, and MiniPlayer without flashing duplicate
+ * covers.
+ */
+@Composable
+internal fun MeloXIOSNowPlayingScene(
+    state: MeloXPlaybackUiState,
+    page: MeloXNowPlayingPage,
+    transitionSourcePage: MeloXNowPlayingPage,
+    onDismiss: () -> Unit,
+    onPageChanged: (MeloXNowPlayingPage) -> Unit,
+    onShowActions: () -> Unit,
+) {
+    val directLyricsQueue = isDirectLyricsQueueTransition(transitionSourcePage, page)
+
+    val artworkVisible = page == MeloXNowPlayingPage.Artwork
+    val lyricsVisible = page == MeloXNowPlayingPage.Lyrics
+    val queueVisible = page == MeloXNowPlayingPage.Queue
+
+    val artworkAlpha by animateFloatAsState(
+        targetValue = if (artworkVisible) 1f else 0f,
+        animationSpec = if (artworkVisible) {
+            tween(durationMillis = 220, delayMillis = 70, easing = FastOutSlowInEasing)
+        } else {
+            tween(durationMillis = 240, easing = FastOutSlowInEasing)
+        },
+        label = "scene-artwork-details-alpha",
+    )
+    val artworkOffset by animateDpAsState(
+        targetValue = if (artworkVisible) 0.dp else (-300).dp,
+        animationSpec = if (artworkVisible) {
+            tween(durationMillis = 220, delayMillis = 70, easing = FastOutSlowInEasing)
+        } else {
+            tween(durationMillis = 240, easing = FastOutSlowInEasing)
+        },
+        label = "scene-artwork-details-offset",
+    )
+
+    val lyricsAlpha by animateFloatAsState(
+        targetValue = if (lyricsVisible) 1f else 0f,
+        animationSpec = when {
+            directLyricsQueue -> tween(440, easing = FastOutSlowInEasing)
+            lyricsVisible -> tween(340, delayMillis = 110, easing = FastOutSlowInEasing)
+            transitionSourcePage == MeloXNowPlayingPage.Lyrics -> tween(240, easing = FastOutSlowInEasing)
+            else -> tween(120)
+        },
+        label = "scene-lyrics-alpha",
+    )
+    val lyricsOffset by animateDpAsState(
+        targetValue = if (page == MeloXNowPlayingPage.Artwork) 400.dp else 0.dp,
+        animationSpec = when {
+            directLyricsQueue -> tween(440, easing = FastOutSlowInEasing)
+            lyricsVisible -> tween(340, delayMillis = 110, easing = FastOutSlowInEasing)
+            transitionSourcePage == MeloXNowPlayingPage.Lyrics -> tween(240, easing = FastOutSlowInEasing)
+            else -> tween(120)
+        },
+        label = "scene-lyrics-offset",
+    )
+    val lyricsScale by animateFloatAsState(
+        targetValue = if (page == MeloXNowPlayingPage.Queue) 0.92f else 1f,
+        animationSpec = if (directLyricsQueue) {
+            tween(440, easing = FastOutSlowInEasing)
+        } else {
+            tween(240, easing = FastOutSlowInEasing)
+        },
+        label = "scene-lyrics-scale",
+    )
+
+    val queueAlpha by animateFloatAsState(
+        targetValue = if (queueVisible) 1f else 0f,
+        animationSpec = when {
+            directLyricsQueue -> tween(440, easing = FastOutSlowInEasing)
+            queueVisible -> tween(340, delayMillis = 110, easing = FastOutSlowInEasing)
+            transitionSourcePage == MeloXNowPlayingPage.Queue -> tween(240, easing = FastOutSlowInEasing)
+            else -> tween(120)
+        },
+        label = "scene-queue-alpha",
+    )
+    val queueOffset by animateDpAsState(
+        targetValue = if (page == MeloXNowPlayingPage.Artwork) 400.dp else 0.dp,
+        animationSpec = when {
+            directLyricsQueue -> tween(440, easing = FastOutSlowInEasing)
+            queueVisible -> tween(340, delayMillis = 110, easing = FastOutSlowInEasing)
+            transitionSourcePage == MeloXNowPlayingPage.Queue -> tween(240, easing = FastOutSlowInEasing)
+            else -> tween(120)
+        },
+        label = "scene-queue-offset",
+    )
+    val queueScale by animateFloatAsState(
+        targetValue = if (page == MeloXNowPlayingPage.Lyrics) 0.92f else 1f,
+        animationSpec = if (directLyricsQueue) {
+            tween(440, easing = FastOutSlowInEasing)
+        } else {
+            tween(240, easing = FastOutSlowInEasing)
+        },
+        label = "scene-queue-scale",
+    )
+
+    val headerAlpha by animateFloatAsState(
+        targetValue = if (artworkVisible) 0f else 1f,
+        animationSpec = if (artworkVisible) {
+            tween(240, easing = FastOutSlowInEasing)
+        } else {
+            tween(400, delayMillis = 80, easing = FastOutSlowInEasing)
+        },
+        label = "scene-song-header-alpha",
+    )
+    val headerOffset by animateDpAsState(
+        targetValue = if (artworkVisible) 40.dp else 0.dp,
+        animationSpec = if (artworkVisible) {
+            tween(240, easing = FastOutSlowInEasing)
+        } else {
+            tween(400, delayMillis = 80, easing = FastOutSlowInEasing)
+        },
+        label = "scene-song-header-offset",
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 32.dp),
+    ) {
+        SceneGrabber(onDismiss)
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        ) {
+            // Artwork-page details keep the same layout slot as the persistent
+            // artwork layer, but never draw a second image.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(if (artworkVisible) 2f else 0f)
+                    .graphicsLayer {
+                        alpha = artworkAlpha
+                        translationY = artworkOffset.toPx()
+                    },
+            ) {
+                ArtworkDetailsWithoutArtwork(
+                    state = state,
+                    onShowActions = onShowActions,
+                )
+            }
+
+            // Resident lyrics start 400dp below the page, wait 110ms, then use
+            // the upstream 340ms smooth entrance. When moving directly to Queue
+            // they stay resident and scale to 0.92 while fading.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(if (lyricsVisible) 2f else 0f)
+                    .graphicsLayer {
+                        alpha = lyricsAlpha
+                        translationY = lyricsOffset.toPx()
+                        scaleX = lyricsScale
+                        scaleY = lyricsScale
+                    }
+                    .padding(top = 88.dp),
+            ) {
+                MeloXIOSLyricsPanel(
+                    state = state,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            // Queue uses the same resident-page timing as upstream. Its own song
+            // header is suppressed; the shared header/persistent artwork above it
+            // occupy the reference 72dp slot instead.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(if (queueVisible) 2f else 0f)
+                    .graphicsLayer {
+                        alpha = queueAlpha
+                        translationY = queueOffset.toPx()
+                        scaleX = queueScale
+                        scaleY = queueScale
+                    },
+            ) {
+                MeloXQueuePanel(
+                    state = state,
+                    modifier = Modifier.fillMaxSize(),
+                    showSongHeader = false,
+                )
+            }
+
+            // The 72dp artwork itself is owned by SharedHost. This row only draws
+            // its title/artist/actions counterpart so both Lyrics and Queue share
+            // exactly one header geometry, matching upstream NowPlayingView.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(72.dp)
+                    .zIndex(3f)
+                    .graphicsLayer {
+                        alpha = headerAlpha
+                        translationY = headerOffset.toPx()
+                    }
+                    .padding(start = 84.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = state.title.ifBlank { "正在播放" },
+                        color = Color.White,
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state.artist,
+                        color = Color.White.copy(alpha = 0.64f),
+                        fontSize = 18.sp,
+                        lineHeight = 22.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onShowActions),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "•••",
+                        color = Color.White,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+        }
+
+        MeloXNowPlayingCoreControls(
+            state = state,
+            page = page,
+            onPageSelected = { destination ->
+                onPageChanged(
+                    if (page == destination) {
+                        MeloXNowPlayingPage.Artwork
+                    } else {
+                        destination
+                    },
+                )
+            },
+        )
+    }
+}
+
+@Composable
+private fun SceneGrabber(onDismiss: () -> Unit) {
+    val interaction = androidx.compose.runtime.remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.88f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium,
+        ),
+        label = "scene-grabber-scale",
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(30.dp)
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = onDismiss,
+            ),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .size(width = 60.dp, height = 5.dp)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.52f)),
+        )
+    }
+}
+
+@Composable
+private fun ArtworkDetailsWithoutArtwork(
+    state: MeloXPlaybackUiState,
+    onShowActions: () -> Unit,
+) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val artworkSize = maxOf(
+            170.dp,
+            minOf(maxWidth + 16.dp, maxHeight - 92.dp),
+        )
+
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.weight(1f))
+            Spacer(Modifier.size(artworkSize))
+            Spacer(Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = state.title.ifBlank { "正在播放" },
+                        color = Color.White,
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = state.artist,
+                        color = Color.White.copy(alpha = 0.64f),
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onShowActions),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "•••",
+                        color = Color.White,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+private fun isDirectLyricsQueueTransition(
+    source: MeloXNowPlayingPage,
+    target: MeloXNowPlayingPage,
+): Boolean =
+    (source == MeloXNowPlayingPage.Lyrics && target == MeloXNowPlayingPage.Queue) ||
+        (source == MeloXNowPlayingPage.Queue && target == MeloXNowPlayingPage.Lyrics)

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
@@ -44,8 +44,9 @@ import androidx.compose.ui.zIndex
  *
  * The actual artwork is intentionally not drawn here. SharedHost owns one
  * persistent artwork layer so the same image can move between the full artwork
- * frame, the 72dp song-header frame, and MiniPlayer without flashing duplicate
- * covers.
+ * frame and the 72dp alternate-page header. Outer dismissal is page-aware: the
+ * Artwork/Queue image can continue into MiniPlayer, while Lyrics lets MiniPlayer
+ * own the waiting artwork at its final location.
  */
 @Composable
 internal fun MeloXIOSNowPlayingScene(
@@ -55,6 +56,7 @@ internal fun MeloXIOSNowPlayingScene(
     onDismiss: () -> Unit,
     onPageChanged: (MeloXNowPlayingPage) -> Unit,
     onShowActions: () -> Unit,
+    grabberDragModifier: Modifier = Modifier,
 ) {
     val directLyricsQueue = isDirectLyricsQueueTransition(transitionSourcePage, page)
 
@@ -166,15 +168,16 @@ internal fun MeloXIOSNowPlayingScene(
             .statusBarsPadding()
             .padding(horizontal = 32.dp),
     ) {
-        SceneGrabber(onDismiss)
+        SceneGrabber(
+            onDismiss = onDismiss,
+            dragModifier = grabberDragModifier,
+        )
 
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            // Artwork-page details keep the same layout slot as the persistent
-            // artwork layer, but never draw a second image.
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -190,9 +193,6 @@ internal fun MeloXIOSNowPlayingScene(
                 )
             }
 
-            // Resident lyrics start 400dp below the page, wait 110ms, then use
-            // the upstream 340ms smooth entrance. When moving directly to Queue
-            // they stay resident and scale to 0.92 while fading.
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -211,9 +211,6 @@ internal fun MeloXIOSNowPlayingScene(
                 )
             }
 
-            // Queue uses the same resident-page timing as upstream. Its own song
-            // header is suppressed; the shared header/persistent artwork above it
-            // occupy the reference 72dp slot instead.
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -232,9 +229,6 @@ internal fun MeloXIOSNowPlayingScene(
                 )
             }
 
-            // The 72dp artwork itself is owned by SharedHost. This row only draws
-            // its title/artist/actions counterpart so both Lyrics and Queue share
-            // exactly one header geometry, matching upstream NowPlayingView.
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -301,7 +295,10 @@ internal fun MeloXIOSNowPlayingScene(
 }
 
 @Composable
-private fun SceneGrabber(onDismiss: () -> Unit) {
+private fun SceneGrabber(
+    onDismiss: () -> Unit,
+    dragModifier: Modifier,
+) {
     val interaction = androidx.compose.runtime.remember { MutableInteractionSource() }
     val pressed by interaction.collectIsPressedAsState()
     val scale by animateFloatAsState(
@@ -317,6 +314,7 @@ private fun SceneGrabber(onDismiss: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .height(30.dp)
+            .then(dragModifier)
             .clickable(
                 interactionSource = interaction,
                 indication = null,

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
@@ -6,11 +6,13 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
@@ -21,27 +23,36 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource.Companion.UserInput
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.kyant.backdrop.backdrops.layerBackdrop
+import com.kyant.backdrop.backdrops.rememberLayerBackdrop
+import com.lladlam.melox.ui.glass.LocalMeloXBackdrop
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
@@ -58,9 +69,19 @@ fun MeloXIOSNowPlayingSharedHost(
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     var page by remember(state.mediaId) { mutableStateOf(MeloXNowPlayingPage.Artwork) }
+    var transitionSourcePage by remember(state.mediaId) {
+        mutableStateOf(MeloXNowPlayingPage.Artwork)
+    }
+    var showActions by remember(state.mediaId) { mutableStateOf(false) }
     var gestureCollapseProgress by remember(state.mediaId) { mutableFloatStateOf(0f) }
     var settleJob by remember(state.mediaId) { mutableStateOf<Job?>(null) }
     val scope = rememberCoroutineScope()
+
+    // Two distinct scenes avoid recursive glass sampling:
+    // 1) controls sample only the flowing-light base scene;
+    // 2) the actions sheet samples the fully composed Now Playing scene.
+    val playerControlBackdrop = rememberLayerBackdrop()
+    val actionsBackdrop = rememberLayerBackdrop()
 
     val expansionProgress by animatedVisibilityScope.transition.animateFloat(
         transitionSpec = { meloXPlayerLinearFloatSpec() },
@@ -72,8 +93,10 @@ fun MeloXIOSNowPlayingSharedHost(
     val backdropAlpha = smoothStep(expansionProgress, 0.08f, 0.58f)
     val fullPlayerAlpha = smoothStep(expansionProgress, 0.46f, 0.90f)
     val collapseProgress = (1f - expansionProgress).coerceIn(0f, 1f)
-    // Keep the fully expanded player softly rounded instead of snapping to
-    // square screen corners. As it approaches MiniPlayer, round it a bit more.
+    val latestCollapseProgress = rememberUpdatedState(collapseProgress)
+    val latestPage = rememberUpdatedState(page)
+
+    // Keep a soft full-screen radius and increase it toward MiniPlayer.
     val cornerRadius = (24f + 8f * smoothStep(collapseProgress, 0f, 1f)).dp
 
     val sharedContainerModifier = with(sharedTransitionScope) {
@@ -94,93 +117,169 @@ fun MeloXIOSNowPlayingSharedHost(
         contentAlignment = Alignment.TopCenter,
     ) {
         val dragRangePx = (constraints.maxHeight * 0.86f).coerceAtLeast(1f)
-        val dragState = rememberDraggableState { delta ->
-            gestureCollapseProgress = (
-                gestureCollapseProgress + delta / dragRangePx
-                ).coerceIn(0f, 0.999f)
+
+        fun seekCollapseBy(delta: Float) {
+            val old = gestureCollapseProgress
+            val next = (old + delta / dragRangePx).coerceIn(0f, 0.999f)
+            if (next == old) return
+            gestureCollapseProgress = next
             scope.launch(start = CoroutineStart.UNDISPATCHED) {
-                onSeekCollapse(gestureCollapseProgress)
+                onSeekCollapse(next)
             }
         }
 
-        Box(
-            modifier = sharedContainerModifier
-                .fillMaxSize()
-                .clip(RoundedCornerShape(cornerRadius))
-                .draggable(
-                    state = dragState,
-                    orientation = Orientation.Vertical,
-                    enabled = page == MeloXNowPlayingPage.Artwork,
-                    onDragStarted = {
-                        // A new gesture always takes ownership immediately. If a
-                        // previous short drag is still springing back, cancel that
-                        // settle instead of blocking the next pointer gesture until
-                        // the old animation completes.
-                        settleJob?.cancelAndJoin()
-                        settleJob = null
+        fun settleFromCurrent(velocity: Float) {
+            val releaseProgress = gestureCollapseProgress
+            val shouldCollapse = releaseProgress >= 0.42f || velocity >= 1200f
+            settleJob?.cancel()
+            settleJob = scope.launch {
+                onSettleCollapse(shouldCollapse)
+                if (!shouldCollapse) {
+                    gestureCollapseProgress = 0f
+                }
+                settleJob = null
+            }
+        }
 
-                        // Resume from the exact visual position where the interrupted
-                        // settle currently is, rather than resetting to Full and
-                        // producing a jump on repeated short drags.
-                        gestureCollapseProgress = collapseProgress.coerceIn(0f, 0.999f)
-                        onSeekCollapse(gestureCollapseProgress)
-                    },
-                    onDragStopped = { velocity ->
-                        val releaseProgress = gestureCollapseProgress
-                        val shouldCollapse = releaseProgress >= 0.42f || velocity >= 1200f
+        val dragState = rememberDraggableState { delta ->
+            seekCollapseBy(delta)
+        }
 
-                        // Do not suspend draggable until the settle animation ends.
-                        // Keep it in a cancellable job so the next touch can interrupt
-                        // the spring and continue from the current frame immediately.
+        // Lyrics/Queue own scrollable content. Let the child consume normal
+        // scrolling first; only leftover downward drag at its top edge starts
+        // player collapse. Once collapse has started, this connection owns both
+        // directions so the finger can reverse the interactive transition.
+        val alternatePageCollapseConnection = remember(dragRangePx) {
+            object : NestedScrollConnection {
+                override fun onPreScroll(
+                    available: Offset,
+                    source: NestedScrollSource,
+                ): Offset {
+                    if (source != UserInput || latestPage.value == MeloXNowPlayingPage.Artwork) {
+                        return Offset.Zero
+                    }
+                    if (gestureCollapseProgress <= 0f) return Offset.Zero
+                    seekCollapseBy(available.y)
+                    return Offset(x = 0f, y = available.y)
+                }
+
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource,
+                ): Offset {
+                    if (source != UserInput || latestPage.value == MeloXNowPlayingPage.Artwork) {
+                        return Offset.Zero
+                    }
+                    if (available.y <= 0f && gestureCollapseProgress <= 0f) {
+                        return Offset.Zero
+                    }
+
+                    if (gestureCollapseProgress <= 0f && available.y > 0f) {
                         settleJob?.cancel()
-                        settleJob = scope.launch {
-                            onSettleCollapse(shouldCollapse)
-                            if (!shouldCollapse) {
-                                gestureCollapseProgress = 0f
-                            }
-                            settleJob = null
-                        }
-                    },
-                ),
+                        settleJob = null
+                        gestureCollapseProgress = latestCollapseProgress.value.coerceIn(0f, 0.999f)
+                    }
+                    seekCollapseBy(available.y)
+                    return Offset(x = 0f, y = available.y)
+                }
+
+                override suspend fun onPreFling(available: Velocity): Velocity {
+                    if (latestPage.value == MeloXNowPlayingPage.Artwork ||
+                        gestureCollapseProgress <= 0f
+                    ) {
+                        return Velocity.Zero
+                    }
+                    settleFromCurrent(available.y)
+                    return available
+                }
+            }
+        }
+
+        // actionsBackdrop records the complete player scene. The actions sheet is
+        // rendered outside this layer below, so it can blur the actual current
+        // Lyrics/Queue/Artwork page without feeding back into its own source.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .layerBackdrop(actionsBackdrop),
         ) {
             Box(
-                modifier = Modifier
+                modifier = sharedContainerModifier
                     .fillMaxSize()
-                    .graphicsLayer { alpha = backdropAlpha },
+                    .clip(RoundedCornerShape(cornerRadius))
+                    .nestedScroll(alternatePageCollapseConnection)
+                    .draggable(
+                        state = dragState,
+                        orientation = Orientation.Vertical,
+                        enabled = page == MeloXNowPlayingPage.Artwork,
+                        onDragStarted = {
+                            settleJob?.cancelAndJoin()
+                            settleJob = null
+                            gestureCollapseProgress = latestCollapseProgress.value
+                                .coerceIn(0f, 0.999f)
+                            onSeekCollapse(gestureCollapseProgress)
+                        },
+                        onDragStopped = { velocity ->
+                            settleFromCurrent(velocity)
+                        },
+                    ),
             ) {
-                MeloXFlowingLightBackdrop(
-                    artworkUrl = state.artworkUrl,
-                    isPlaying = state.isPlaying,
-                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .layerBackdrop(playerControlBackdrop)
+                        .graphicsLayer { alpha = backdropAlpha },
+                ) {
+                    MeloXFlowingLightBackdrop(
+                        artworkUrl = state.artworkUrl,
+                        isPlaying = state.isPlaying,
+                    )
+                }
+
+                CompositionLocalProvider(LocalMeloXBackdrop provides playerControlBackdrop) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer { alpha = fullPlayerAlpha },
+                    ) {
+                        MeloXIOSNowPlayingScene(
+                            state = state,
+                            page = page,
+                            transitionSourcePage = transitionSourcePage,
+                            onDismiss = onDismiss,
+                            onPageChanged = { destination ->
+                                if (destination != page) {
+                                    transitionSourcePage = page
+                                    page = destination
+                                }
+                            },
+                            onShowActions = { showActions = true },
+                        )
+                    }
+                }
             }
 
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer { alpha = fullPlayerAlpha },
-            ) {
-                MeloXIOSNowPlayingV2(
-                    state = state,
-                    onDismiss = onDismiss,
-                    page = page,
-                    onPageChanged = { page = it },
-                    drawBackdrop = false,
-                    drawArtwork = false,
-                )
-            }
-
+            // One persistent artwork layer is shared by all internal pages. It
+            // animates between the large artwork frame and upstream's 72dp song
+            // header frame, then remains the MiniPlayer identity element on close.
+            SharedArtworkDestination(
+                state = state,
+                page = page,
+                expansionProgress = expansionProgress,
+                sharedTransitionScope = sharedTransitionScope,
+                animatedVisibilityScope = animatedVisibilityScope,
+            )
         }
 
-        // Keep the artwork destination in the stable SharedTransition root
-        // coordinate space. Nesting it inside the remeasured sharedBounds made
-        // its target move while the artwork itself was also transforming.
-        SharedArtworkDestination(
-            state = state,
-            page = page,
-            expansionProgress = expansionProgress,
-            sharedTransitionScope = sharedTransitionScope,
-            animatedVisibilityScope = animatedVisibilityScope,
-        )
+        // Same-window overlay: this is deliberately outside actionsBackdrop.
+        CompositionLocalProvider(LocalMeloXBackdrop provides actionsBackdrop) {
+            MeloXNowPlayingActionsSheet(
+                state = state,
+                visible = showActions,
+                onDismiss = { showActions = false },
+            )
+        }
     }
 }
 
@@ -193,6 +292,17 @@ private fun SharedArtworkDestination(
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
+    // Upstream keeps one artwork alive and animates its frame for 0.48s when
+    // switching between artwork and alternate pages.
+    val headerProgress by animateFloatAsState(
+        targetValue = if (page == MeloXNowPlayingPage.Artwork) 0f else 1f,
+        animationSpec = tween(
+            durationMillis = 480,
+            easing = FastOutSlowInEasing,
+        ),
+        label = "persistent-artwork-page-frame",
+    )
+
     val playbackScale by animateFloatAsState(
         targetValue = if (state.isPlaying) 1f else 0.74f,
         animationSpec = if (state.isPlaying) {
@@ -219,14 +329,9 @@ private fun SharedArtworkDestination(
         label = "shared-artwork-shadow",
     )
 
-    val artworkAlpha = if (page == MeloXNowPlayingPage.Artwork) {
-        1f
-    } else {
-        1f - smoothStep(expansionProgress, 0.72f, 0.985f)
-    }
-
     val fullScreenScaleBlend = smoothStep(expansionProgress, 0.30f, 0.88f)
-    val effectiveScale = 1f + (playbackScale - 1f) * fullScreenScaleBlend
+    val effectiveScale = 1f +
+        (playbackScale - 1f) * fullScreenScaleBlend * (1f - headerProgress)
 
     Column(
         modifier = Modifier
@@ -241,77 +346,62 @@ private fun SharedArtworkDestination(
                 .fillMaxWidth()
                 .weight(1f),
         ) {
-            val artworkSize = maxOf(
+            val fullArtworkSize = maxOf(
                 170.dp,
                 minOf(maxWidth + 16.dp, maxHeight - 92.dp),
             )
+            val artworkFooterHeight = 78.dp
+            val fullX = ((maxWidth - fullArtworkSize) / 2f).coerceAtLeast((-8).dp)
+            val fullY = (maxHeight - fullArtworkSize - artworkFooterHeight)
+                .coerceAtLeast(0.dp)
 
-            Column(Modifier.fillMaxSize()) {
-                Spacer(Modifier.weight(1f))
+            val targetSize = lerpDp(fullArtworkSize, 72.dp, headerProgress)
+            val targetX = lerpDp(fullX, 0.dp, headerProgress)
+            val targetY = lerpDp(fullY, 0.dp, headerProgress)
+            val targetRadius = lerpDp(12.dp, 12.dp, headerProgress)
 
-                val sharedModifier = with(sharedTransitionScope) {
-                    Modifier.sharedElement(
-                        sharedContentState = rememberSharedContentState(
-                            key = sharedArtworkKey(state.mediaId),
-                        ),
-                        animatedVisibilityScope = animatedVisibilityScope,
-                        boundsTransform = MeloXPlayerLinearBoundsTransform,
-                        zIndexInOverlay = 3f,
-                    )
-                }
+            val sharedModifier = with(sharedTransitionScope) {
+                Modifier.sharedElement(
+                    sharedContentState = rememberSharedContentState(
+                        key = sharedArtworkKey(state.mediaId),
+                    ),
+                    animatedVisibilityScope = animatedVisibilityScope,
+                    boundsTransform = MeloXPlayerLinearBoundsTransform,
+                    zIndexInOverlay = 3f,
+                )
+            }
 
-                Box(
-                    modifier = sharedModifier
-                        .size(artworkSize),
-                ) {
-                    Artwork(
-                        url = state.artworkUrl,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .graphicsLayer {
-                                alpha = artworkAlpha
-                                scaleX = effectiveScale
-                                scaleY = effectiveScale
-                            }
-                            .shadow(
-                                elevation = shadowElevation,
-                                shape = RoundedCornerShape(12.dp),
-                                clip = false,
-                                ambientColor = Color.Black.copy(alpha = 0.28f * artworkAlpha),
-                                spotColor = Color.Black.copy(alpha = 0.28f * artworkAlpha),
-                            )
-                            .clip(RoundedCornerShape(12.dp)),
-                    )
-                }
-
-                Spacer(Modifier.height(20.dp))
-
-                Column(Modifier.fillMaxWidth()) {
-                    Text(
-                        text = state.title.ifBlank { "正在播放" },
-                        color = Color.Transparent,
-                        fontSize = 20.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                    )
-                    Text(
-                        text = state.artist.ifBlank { " " },
-                        color = Color.Transparent,
-                        fontSize = 20.sp,
-                        lineHeight = 24.sp,
-                        maxLines = 1,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
-                }
-
-                Spacer(Modifier.height(8.dp))
+            Box(
+                modifier = sharedModifier
+                    .offset(x = targetX, y = targetY)
+                    .size(targetSize),
+            ) {
+                Artwork(
+                    url = state.artworkUrl,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            scaleX = effectiveScale
+                            scaleY = effectiveScale
+                        }
+                        .shadow(
+                            elevation = shadowElevation * (1f - headerProgress * 0.55f),
+                            shape = RoundedCornerShape(targetRadius),
+                            clip = false,
+                            ambientColor = Color.Black.copy(alpha = 0.28f),
+                            spotColor = Color.Black.copy(alpha = 0.28f),
+                        )
+                        .clip(RoundedCornerShape(targetRadius)),
+                )
             }
         }
 
-        Spacer(Modifier.height(279.dp))
+        Spacer(Modifier.height(MeloXNowPlayingControlsHeight.dp))
     }
 }
+
+private fun lerpDp(start: androidx.compose.ui.unit.Dp, end: androidx.compose.ui.unit.Dp, fraction: Float) =
+    start + (end - start) * fraction.coerceIn(0f, 1f)
 
 private fun smoothStep(value: Float, start: Float, end: Float): Float {
     if (end <= start) return if (value >= end) 1f else 0f

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
@@ -46,8 +46,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource.Companion.UserInput
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
@@ -78,8 +78,8 @@ fun MeloXIOSNowPlayingSharedHost(
     val scope = rememberCoroutineScope()
 
     // Two distinct scenes avoid recursive glass sampling:
-    // 1) controls sample only the flowing-light base scene;
-    // 2) the actions sheet samples the fully composed Now Playing scene.
+    // controls sample the flowing-light player scene; the actions overlay samples
+    // the fully composed Now Playing scene from outside that recording layer.
     val playerControlBackdrop = rememberLayerBackdrop()
     val actionsBackdrop = rememberLayerBackdrop()
 
@@ -95,8 +95,6 @@ fun MeloXIOSNowPlayingSharedHost(
     val collapseProgress = (1f - expansionProgress).coerceIn(0f, 1f)
     val latestCollapseProgress = rememberUpdatedState(collapseProgress)
     val latestPage = rememberUpdatedState(page)
-
-    // Keep a soft full-screen radius and increase it toward MiniPlayer.
     val cornerRadius = (24f + 8f * smoothStep(collapseProgress, 0f, 1f)).dp
 
     val sharedContainerModifier = with(sharedTransitionScope) {
@@ -128,6 +126,13 @@ fun MeloXIOSNowPlayingSharedHost(
             }
         }
 
+        suspend fun beginCollapseDrag() {
+            settleJob?.cancelAndJoin()
+            settleJob = null
+            gestureCollapseProgress = latestCollapseProgress.value.coerceIn(0f, 0.999f)
+            onSeekCollapse(gestureCollapseProgress)
+        }
+
         fun settleFromCurrent(velocity: Float) {
             val releaseProgress = gestureCollapseProgress
             val shouldCollapse = releaseProgress >= 0.42f || velocity >= 1200f
@@ -141,14 +146,12 @@ fun MeloXIOSNowPlayingSharedHost(
             }
         }
 
-        val dragState = rememberDraggableState { delta ->
-            seekCollapseBy(delta)
-        }
+        val dragState = rememberDraggableState { delta -> seekCollapseBy(delta) }
 
-        // Lyrics/Queue own scrollable content. Let the child consume normal
-        // scrolling first; only leftover downward drag at its top edge starts
-        // player collapse. Once collapse has started, this connection owns both
-        // directions so the finger can reverse the interactive transition.
+        // Lyrics/Queue own scrollable content. Child scrolling wins normally;
+        // leftover downward motion at the top edge begins player collapse. Once
+        // collapse has started, this connection owns both directions so the user
+        // can reverse the transition without lifting the finger.
         val alternatePageCollapseConnection = remember(dragRangePx) {
             object : NestedScrollConnection {
                 override fun onPreScroll(
@@ -174,7 +177,6 @@ fun MeloXIOSNowPlayingSharedHost(
                     if (available.y <= 0f && gestureCollapseProgress <= 0f) {
                         return Offset.Zero
                     }
-
                     if (gestureCollapseProgress <= 0f && available.y > 0f) {
                         settleJob?.cancel()
                         settleJob = null
@@ -196,9 +198,19 @@ fun MeloXIOSNowPlayingSharedHost(
             }
         }
 
-        // actionsBackdrop records the complete player scene. The actions sheet is
-        // rendered outside this layer below, so it can blur the actual current
-        // Lyrics/Queue/Artwork page without feeding back into its own source.
+        // Alternate pages can always be dismissed by dragging the grabber even
+        // when their list is currently scrolled away from the top.
+        val alternateGrabberDragModifier = if (page != MeloXNowPlayingPage.Artwork) {
+            Modifier.draggable(
+                state = dragState,
+                orientation = Orientation.Vertical,
+                onDragStarted = { beginCollapseDrag() },
+                onDragStopped = { velocity -> settleFromCurrent(velocity) },
+            )
+        } else {
+            Modifier
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -213,16 +225,8 @@ fun MeloXIOSNowPlayingSharedHost(
                         state = dragState,
                         orientation = Orientation.Vertical,
                         enabled = page == MeloXNowPlayingPage.Artwork,
-                        onDragStarted = {
-                            settleJob?.cancelAndJoin()
-                            settleJob = null
-                            gestureCollapseProgress = latestCollapseProgress.value
-                                .coerceIn(0f, 0.999f)
-                            onSeekCollapse(gestureCollapseProgress)
-                        },
-                        onDragStopped = { velocity ->
-                            settleFromCurrent(velocity)
-                        },
+                        onDragStarted = { beginCollapseDrag() },
+                        onDragStopped = { velocity -> settleFromCurrent(velocity) },
                     ),
             ) {
                 Box(
@@ -255,14 +259,12 @@ fun MeloXIOSNowPlayingSharedHost(
                                 }
                             },
                             onShowActions = { showActions = true },
+                            grabberDragModifier = alternateGrabberDragModifier,
                         )
                     }
                 }
             }
 
-            // One persistent artwork layer is shared by all internal pages. It
-            // animates between the large artwork frame and upstream's 72dp song
-            // header frame, then remains the MiniPlayer identity element on close.
             SharedArtworkDestination(
                 state = state,
                 page = page,
@@ -272,7 +274,6 @@ fun MeloXIOSNowPlayingSharedHost(
             )
         }
 
-        // Same-window overlay: this is deliberately outside actionsBackdrop.
         CompositionLocalProvider(LocalMeloXBackdrop provides actionsBackdrop) {
             MeloXNowPlayingActionsSheet(
                 state = state,
@@ -332,6 +333,17 @@ private fun SharedArtworkDestination(
     val fullScreenScaleBlend = smoothStep(expansionProgress, 0.30f, 0.88f)
     val effectiveScale = 1f +
         (playbackScale - 1f) * fullScreenScaleBlend * (1f - headerProgress)
+    val collapseProgress = (1f - expansionProgress).coerceIn(0f, 1f)
+
+    // Lyrics dismissal intentionally does not send the 72dp header artwork down
+    // the shared-element path. It fades immediately as MiniPlayer's own artwork
+    // appears at the final MiniPlayer location and waits for the sheet to catch up.
+    // Queue keeps the shared path so its top-left artwork visibly travels home.
+    val persistentArtworkAlpha = if (page == MeloXNowPlayingPage.Lyrics) {
+        1f - smoothStep(collapseProgress, 0f, 0.10f)
+    } else {
+        1f
+    }
 
     Column(
         modifier = Modifier
@@ -358,17 +370,22 @@ private fun SharedArtworkDestination(
             val targetSize = lerpDp(fullArtworkSize, 72.dp, headerProgress)
             val targetX = lerpDp(fullX, 0.dp, headerProgress)
             val targetY = lerpDp(fullY, 0.dp, headerProgress)
-            val targetRadius = lerpDp(12.dp, 12.dp, headerProgress)
+            val targetRadius = 12.dp
 
-            val sharedModifier = with(sharedTransitionScope) {
-                Modifier.sharedElement(
-                    sharedContentState = rememberSharedContentState(
-                        key = sharedArtworkKey(state.mediaId),
-                    ),
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    boundsTransform = MeloXPlayerLinearBoundsTransform,
-                    zIndexInOverlay = 3f,
-                )
+            val artworkSharedState = with(sharedTransitionScope) {
+                rememberSharedContentState(key = sharedArtworkKey(state.mediaId))
+            }
+            val sharedModifier = if (page == MeloXNowPlayingPage.Lyrics) {
+                Modifier
+            } else {
+                with(sharedTransitionScope) {
+                    Modifier.sharedElement(
+                        sharedContentState = artworkSharedState,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        boundsTransform = MeloXPlayerLinearBoundsTransform,
+                        zIndexInOverlay = 3f,
+                    )
+                }
             }
 
             Box(
@@ -381,6 +398,7 @@ private fun SharedArtworkDestination(
                     modifier = Modifier
                         .fillMaxSize()
                         .graphicsLayer {
+                            alpha = persistentArtworkAlpha
                             scaleX = effectiveScale
                             scaleY = effectiveScale
                         }
@@ -388,8 +406,8 @@ private fun SharedArtworkDestination(
                             elevation = shadowElevation * (1f - headerProgress * 0.55f),
                             shape = RoundedCornerShape(targetRadius),
                             clip = false,
-                            ambientColor = Color.Black.copy(alpha = 0.28f),
-                            spotColor = Color.Black.copy(alpha = 0.28f),
+                            ambientColor = Color.Black.copy(alpha = 0.28f * persistentArtworkAlpha),
+                            spotColor = Color.Black.copy(alpha = 0.28f * persistentArtworkAlpha),
                         )
                         .clip(RoundedCornerShape(targetRadius)),
                 )

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXNowPlayingActionsSheet.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXNowPlayingActionsSheet.kt
@@ -4,13 +4,16 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,7 +25,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -39,47 +41,66 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import com.lladlam.melox.ui.glass.meloXLiquidButton
 import java.net.URLEncoder
 
 private enum class ActionPage { Main, Sleep }
 
+/**
+ * Same-window Now Playing overlay.
+ *
+ * This intentionally does not use Dialog: a platform Dialog owns a separate
+ * window and therefore cannot sample the Compose Backdrop recorded from the
+ * player underneath it. SharedHost places this composable outside the recorded
+ * Now Playing layer and provides that layer as LocalMeloXBackdrop, so the glass
+ * sheet blurs the actual artwork/lyrics/queue page instead of the app behind it.
+ */
 @Composable
 fun MeloXNowPlayingActionsSheet(
     state: MeloXPlaybackUiState,
     visible: Boolean,
     onDismiss: () -> Unit,
 ) {
-    if (!visible) return
     val context = LocalContext.current
     var page by remember(state.mediaId) { mutableStateOf(ActionPage.Main) }
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(spring(stiffness = 520f)),
+        exit = fadeOut(spring(stiffness = 620f)),
     ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .clickable(indication = null, interactionSource = null, onClick = onDismiss)
+                .background(Color.Black.copy(alpha = 0.22f))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onDismiss,
+                )
                 .padding(horizontal = 18.dp)
                 .navigationBarsPadding(),
             contentAlignment = Alignment.BottomCenter,
         ) {
+            val sheetInteraction = remember { MutableInteractionSource() }
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 18.dp)
                     .meloXLiquidButton(
                         shape = RoundedCornerShape(30.dp),
-                        tint = Color.White.copy(alpha = 0.10f),
-                        surfaceColor = Color.Black.copy(alpha = 0.28f),
-                        blurRadius = 12.dp,
-                        lensRadius = 26.dp,
-                        refractionHeight = 26.dp,
+                        tint = Color.White.copy(alpha = 0.08f),
+                        surfaceColor = Color.Black.copy(alpha = 0.12f),
+                        blurRadius = 14.dp,
+                        lensRadius = 20.dp,
+                        refractionHeight = 22.dp,
                     )
-                    .clickable(enabled = false) {},
+                    // Consume sheet taps so they never reach the dismiss scrim.
+                    .clickable(
+                        interactionSource = sheetInteraction,
+                        indication = null,
+                        onClick = {},
+                    ),
                 color = Color.Transparent,
                 shape = RoundedCornerShape(30.dp),
             ) {
@@ -93,8 +114,12 @@ fun MeloXNowPlayingActionsSheet(
                 ) { selected ->
                     Column(Modifier.padding(horizontal = 18.dp, vertical = 20.dp)) {
                         when (selected) {
-                            ActionPage.Main -> MainActions(state, context, onDismiss) { page = ActionPage.Sleep }
-                            ActionPage.Sleep -> SleepActions(state, onDismiss) { page = ActionPage.Main }
+                            ActionPage.Main -> MainActions(state, context, onDismiss) {
+                                page = ActionPage.Sleep
+                            }
+                            ActionPage.Sleep -> SleepActions(state, onDismiss) {
+                                page = ActionPage.Main
+                            }
                         }
                     }
                 }
@@ -124,20 +149,35 @@ private fun MainActions(
 }
 
 @Composable
-private fun SleepActions(state: MeloXPlaybackUiState, onDismiss: () -> Unit, onBack: () -> Unit) {
+private fun SleepActions(
+    state: MeloXPlaybackUiState,
+    onDismiss: () -> Unit,
+    onBack: () -> Unit,
+) {
     ActionHeader(state, "定时关闭")
     listOf(15, 30, 45, 60).forEach { minutes ->
-        ActionItem("$minutes 分钟后", "◷") { state.setSleepTimer(minutes); onDismiss() }
+        ActionItem("$minutes 分钟后", "◷") {
+            state.setSleepTimer(minutes)
+            onDismiss()
+        }
     }
     if (state.sleepTimerEndRealtimeMs > 0L) {
-        ActionItem("取消定时", "×") { state.cancelSleepTimer(); onDismiss() }
+        ActionItem("取消定时", "×") {
+            state.cancelSleepTimer()
+            onDismiss()
+        }
     }
     ActionItem("返回", "‹", onBack)
 }
 
 @Composable
 private fun ActionHeader(state: MeloXPlaybackUiState, title: String) {
-    Text(title, color = Color.White.copy(alpha = 0.58f), fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+    Text(
+        text = title,
+        color = Color.White.copy(alpha = 0.58f),
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
     Text(
         text = state.title.ifBlank { "正在播放" },
         color = Color.White,
@@ -161,9 +201,19 @@ private fun ActionItem(title: String, symbol: String, onClick: () -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) {
-            Text(symbol, color = Color.White, fontSize = 19.sp, fontWeight = FontWeight.SemiBold)
+            Text(
+                text = symbol,
+                color = Color.White,
+                fontSize = 19.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
         }
-        Text(title, color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+        Text(
+            text = title,
+            color = Color.White,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+        )
         Spacer(Modifier.weight(1f))
     }
 }
@@ -191,6 +241,9 @@ private fun openSearch(context: Context, query: String, type: Int) {
 
 private fun openUrl(context: Context, url: String) {
     runCatching {
-        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXNowPlayingCoreControls.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXNowPlayingCoreControls.kt
@@ -1,0 +1,853 @@
+package com.lladlam.melox.ui.player
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.lladlam.melox.core.account.NeteaseSessionStore
+import com.lladlam.melox.core.audio.MusicQuality
+import com.lladlam.melox.core.audio.MusicQualityPreferences
+import com.lladlam.melox.core.audio.MusicQualityRuntime
+import com.lladlam.melox.core.audio.NeteaseQualityClient
+import com.lladlam.melox.core.audio.SongAudioAvailability
+import com.lladlam.melox.playback.PlaybackCommands
+import com.lladlam.melox.ui.glass.meloXLiquidButton
+import kotlinx.coroutines.delay
+import kotlin.math.roundToLong
+
+internal const val MeloXNowPlayingControlsHeight = 279
+
+@Composable
+internal fun MeloXNowPlayingCoreControls(
+    state: MeloXPlaybackUiState,
+    page: MeloXNowPlayingPage,
+    onPageSelected: (MeloXNowPlayingPage) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(MeloXNowPlayingControlsHeight.dp),
+    ) {
+        SceneProgressControl(state)
+        Spacer(Modifier.height(19.dp))
+        SceneTransportControls(state)
+        Spacer(Modifier.height(31.dp))
+        SceneVolumeControl(state)
+        Spacer(Modifier.height(3.dp))
+        ScenePageSelector(
+            state = state,
+            page = page,
+            onPageSelected = onPageSelected,
+        )
+    }
+}
+
+@Composable
+private fun SceneProgressControl(state: MeloXPlaybackUiState) {
+    val sourceProgress = if (state.durationMs > 0L) {
+        (state.positionMs.toFloat() / state.durationMs.toFloat()).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    var scrubbing by remember { mutableStateOf(false) }
+    var localProgress by remember { mutableFloatStateOf(sourceProgress) }
+    val trackHeight by animateDpAsState(
+        targetValue = if (scrubbing) 6.dp else 4.dp,
+        animationSpec = tween(120),
+        label = "scene-progress-track-height",
+    )
+
+    LaunchedEffect(sourceProgress, scrubbing) {
+        if (!scrubbing) localProgress = sourceProgress
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Slider(
+            value = localProgress,
+            onValueChange = {
+                scrubbing = true
+                localProgress = it.coerceIn(0f, 1f)
+            },
+            onValueChangeFinished = {
+                if (state.durationMs > 0L) {
+                    state.seekTo((state.durationMs * localProgress).roundToLong())
+                }
+                scrubbing = false
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp),
+            thumb = { Spacer(Modifier.size(0.dp)) },
+            track = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(trackHeight)
+                        .clip(CircleShape)
+                        .background(Color.White.copy(alpha = 0.20f)),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(localProgress)
+                            .fillMaxHeight()
+                            .background(Color.White.copy(alpha = 0.96f)),
+                    )
+                }
+            },
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(26.dp),
+        ) {
+            val shownPosition = if (scrubbing) {
+                (state.durationMs * localProgress).roundToLong()
+            } else {
+                state.positionMs
+            }
+            Text(
+                text = sceneFormatDuration(shownPosition),
+                modifier = Modifier.align(Alignment.CenterStart),
+                color = Color.White.copy(alpha = 0.50f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+            )
+
+            SceneQualityChip(
+                state = state,
+                modifier = Modifier.align(Alignment.Center),
+            )
+
+            Text(
+                text = "−${sceneFormatDuration((state.durationMs - shownPosition).coerceAtLeast(0L))}",
+                modifier = Modifier.align(Alignment.CenterEnd),
+                color = Color.White.copy(alpha = 0.50f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SceneQualityChip(
+    state: MeloXPlaybackUiState,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current.applicationContext
+    val qualityClient = remember(context) {
+        NeteaseQualityClient(
+            cookieProvider = { NeteaseSessionStore.readCookie(context) },
+        )
+    }
+    var expanded by remember { mutableStateOf(false) }
+    var selected by remember(context) {
+        mutableStateOf(
+            MusicQualityPreferences.read(context).also { MusicQualityRuntime.selected = it },
+        )
+    }
+    var actual by remember(state.mediaId) {
+        mutableStateOf(MusicQualityRuntime.actualFor(state.mediaId?.toLongOrNull()))
+    }
+    var availability by remember(state.mediaId) {
+        mutableStateOf(SongAudioAvailability.Unknown)
+    }
+
+    LaunchedEffect(state.mediaId) {
+        val songId = state.mediaId?.toLongOrNull() ?: return@LaunchedEffect
+        availability = runCatching { qualityClient.audioAvailability(songId) }
+            .getOrDefault(SongAudioAvailability.Unknown)
+    }
+    LaunchedEffect(state.mediaId, selected) {
+        val songId = state.mediaId?.toLongOrNull() ?: return@LaunchedEffect
+        while (true) {
+            actual = MusicQualityRuntime.actualFor(songId)
+            delay(180L)
+        }
+    }
+
+    val displayQuality = actual ?: selected
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.94f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessHigh,
+        ),
+        label = "scene-quality-chip-press",
+    )
+
+    Box(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .height(24.dp)
+                .clip(RoundedCornerShape(7.dp))
+                .meloXLiquidButton(
+                    shape = RoundedCornerShape(7.dp),
+                    surfaceColor = Color.White.copy(alpha = 0.10f),
+                    lensRadius = 6.dp,
+                    refractionHeight = 9.dp,
+                )
+                .clickable(
+                    interactionSource = interaction,
+                    indication = null,
+                ) { expanded = true }
+                .padding(horizontal = 9.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+            Box(
+                modifier = Modifier.size(14.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                SceneCupertinoGlyph(
+                    kind = SceneGlyphKind.Waveform,
+                    modifier = Modifier.size(12.dp),
+                    color = Color.White.copy(alpha = 0.86f),
+                )
+            }
+            Text(
+                text = displayQuality.title,
+                color = Color.White.copy(alpha = 0.86f),
+                fontSize = 11.sp,
+                lineHeight = 13.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            MusicQuality.entries.forEach { quality ->
+                val supported = availability.supports(quality.apiLevel) != false
+                DropdownMenuItem(
+                    enabled = supported,
+                    text = {
+                        Text(if (quality == selected) "✓ ${quality.title}" else quality.title)
+                    },
+                    onClick = {
+                        selected = quality
+                        actual = null
+                        expanded = false
+                        PlaybackCommands.changeQuality(context, quality)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SceneTransportControls(state: MeloXPlaybackUiState) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(82.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(Modifier.weight(1f))
+        SceneTransportButton(
+            kind = SceneGlyphKind.Backward,
+            visualSize = 34.dp,
+            onClick = {
+                if (state.hasPrevious) state.previous() else state.seekTo(0L)
+            },
+        )
+        Spacer(Modifier.weight(1f))
+        ScenePlayPauseButton(state)
+        Spacer(Modifier.weight(1f))
+        SceneTransportButton(
+            kind = SceneGlyphKind.Forward,
+            visualSize = 34.dp,
+            onClick = state::next,
+        )
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun ScenePlayPauseButton(state: MeloXPlaybackUiState) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.86f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = 620f,
+        ),
+        label = "scene-play-pause-press",
+    )
+
+    Box(
+        modifier = Modifier
+            .size(64.dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .clip(CircleShape)
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = state::togglePlayPause,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedContent(
+            targetState = state.isPlaying,
+            transitionSpec = {
+                (
+                    fadeIn(tween(180)) +
+                        scaleIn(initialScale = 0.78f, animationSpec = tween(200)) +
+                        slideInVertically(tween(200)) { (it * 0.24f).toInt() }
+                    ) togetherWith (
+                    fadeOut(tween(150)) +
+                        scaleOut(targetScale = 0.78f, animationSpec = tween(180)) +
+                        slideOutVertically(tween(180)) { -(it * 0.24f).toInt() }
+                    )
+            },
+            label = "scene-play-pause-symbol-replace",
+        ) { playing ->
+            SceneCupertinoGlyph(
+                kind = if (playing) SceneGlyphKind.Pause else SceneGlyphKind.Play,
+                modifier = Modifier.size(48.dp),
+                color = Color.White,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SceneTransportButton(
+    kind: SceneGlyphKind,
+    visualSize: Dp,
+    onClick: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.84f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = 620f,
+        ),
+        label = "scene-transport-press-${kind.name}",
+    )
+
+    Box(
+        modifier = Modifier
+            .size(64.dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .clip(CircleShape)
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        SceneCupertinoGlyph(
+            kind = kind,
+            modifier = Modifier.size(visualSize),
+            color = Color.White,
+        )
+    }
+}
+
+@Composable
+private fun SceneVolumeControl(state: MeloXPlaybackUiState) {
+    var dragging by remember { mutableStateOf(false) }
+    var localVolume by remember { mutableFloatStateOf(state.volume) }
+    val thumbSize by animateDpAsState(
+        targetValue = if (dragging) 16.dp else 14.dp,
+        animationSpec = tween(120),
+        label = "scene-volume-thumb-size",
+    )
+    val trackHeight by animateDpAsState(
+        targetValue = if (dragging) 4.dp else 3.dp,
+        animationSpec = tween(120),
+        label = "scene-volume-track-height",
+    )
+
+    LaunchedEffect(state.volume, dragging) {
+        if (!dragging) localVolume = state.volume
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(42.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        SceneCupertinoGlyph(
+            kind = SceneGlyphKind.SpeakerLow,
+            modifier = Modifier.size(12.dp),
+            color = Color.White.copy(alpha = 0.62f),
+        )
+
+        Slider(
+            value = localVolume,
+            onValueChange = {
+                dragging = true
+                localVolume = it.coerceIn(0f, 1f)
+                state.changeVolume(localVolume)
+            },
+            onValueChangeFinished = { dragging = false },
+            modifier = Modifier
+                .weight(1f)
+                .height(32.dp),
+            thumb = {
+                Box(
+                    modifier = Modifier
+                        .size(thumbSize)
+                        .shadow(3.dp, CircleShape)
+                        .clip(CircleShape)
+                        .background(Color.White),
+                )
+            },
+            track = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(trackHeight)
+                        .clip(CircleShape)
+                        .background(Color.White.copy(alpha = 0.20f)),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(localVolume)
+                            .fillMaxHeight()
+                            .background(Color.White.copy(alpha = 0.82f)),
+                    )
+                }
+            },
+        )
+
+        SceneCupertinoGlyph(
+            kind = SceneGlyphKind.SpeakerHigh,
+            modifier = Modifier.size(15.dp),
+            color = Color.White.copy(alpha = 0.62f),
+        )
+    }
+}
+
+@Composable
+private fun ScenePageSelector(
+    state: MeloXPlaybackUiState,
+    page: MeloXNowPlayingPage,
+    onPageSelected: (MeloXNowPlayingPage) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(50.dp)
+            .padding(horizontal = 32.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ScenePageButton(
+            kind = SceneGlyphKind.Lyrics,
+            selected = page == MeloXNowPlayingPage.Lyrics,
+            enabled = true,
+            onClick = { onPageSelected(MeloXNowPlayingPage.Lyrics) },
+        )
+
+        ScenePageButton(
+            kind = SceneGlyphKind.PipEnter,
+            selected = false,
+            enabled = false,
+            onClick = {},
+        )
+
+        Box {
+            ScenePageButton(
+                kind = SceneGlyphKind.Queue,
+                selected = page == MeloXNowPlayingPage.Queue,
+                enabled = true,
+                onClick = { onPageSelected(MeloXNowPlayingPage.Queue) },
+            )
+
+            if (
+                page != MeloXNowPlayingPage.Queue &&
+                (state.shuffleEnabled || state.repeatMode != 0)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .size(15.dp)
+                        .clip(CircleShape)
+                        .background(Color.White.copy(alpha = 0.82f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = when {
+                            state.shuffleEnabled -> "S"
+                            state.repeatMode == 1 -> "1"
+                            else -> "R"
+                        },
+                        color = Color.Black.copy(alpha = 0.72f),
+                        fontSize = 7.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScenePageButton(
+    kind: SceneGlyphKind,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val pressScale by animateFloatAsState(
+        targetValue = if (pressed) 0.86f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = 650f,
+        ),
+        label = "scene-page-button-press-${kind.name}",
+    )
+    val selectionScale by animateFloatAsState(
+        targetValue = if (selected) 1.04f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium,
+        ),
+        label = "scene-page-button-selected-${kind.name}",
+    )
+    val backgroundAlpha by animateFloatAsState(
+        targetValue = if (selected) 0.68f else 0f,
+        animationSpec = tween(220, easing = FastOutSlowInEasing),
+        label = "scene-page-button-bg-${kind.name}",
+    )
+
+    Box(
+        modifier = Modifier
+            .size(44.dp)
+            .graphicsLayer {
+                val s = pressScale * selectionScale
+                scaleX = s
+                scaleY = s
+            }
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = backgroundAlpha * 0.16f))
+            .clickable(
+                enabled = enabled,
+                interactionSource = interaction,
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        SceneCupertinoGlyph(
+            kind = kind,
+            modifier = Modifier.size(22.dp),
+            color = when {
+                !enabled -> Color.White.copy(alpha = 0.26f)
+                selected -> Color.Black.copy(alpha = 0.68f)
+                else -> Color.White.copy(alpha = 0.72f)
+            },
+        )
+    }
+}
+
+private enum class SceneGlyphKind {
+    Backward,
+    Forward,
+    Play,
+    Pause,
+    SpeakerLow,
+    SpeakerHigh,
+    Lyrics,
+    PipEnter,
+    Queue,
+    Waveform,
+}
+
+@Composable
+private fun SceneCupertinoGlyph(
+    kind: SceneGlyphKind,
+    modifier: Modifier,
+    color: Color,
+) {
+    Canvas(modifier = modifier) {
+        val w = size.width
+        val h = size.height
+        val min = size.minDimension
+        val stroke = (min * 0.085f).coerceAtLeast(1.35f)
+
+        when (kind) {
+            SceneGlyphKind.Play -> {
+                val p = Path().apply {
+                    moveTo(w * 0.28f, h * 0.13f)
+                    quadraticBezierTo(w * 0.22f, h * 0.10f, w * 0.22f, h * 0.22f)
+                    lineTo(w * 0.22f, h * 0.78f)
+                    quadraticBezierTo(w * 0.22f, h * 0.90f, w * 0.30f, h * 0.86f)
+                    lineTo(w * 0.82f, h * 0.56f)
+                    quadraticBezierTo(w * 0.91f, h * 0.50f, w * 0.82f, h * 0.44f)
+                    close()
+                }
+                drawPath(p, color)
+            }
+
+            SceneGlyphKind.Pause -> {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.24f, h * 0.10f),
+                    size = Size(w * 0.18f, h * 0.80f),
+                    cornerRadius = CornerRadius(w * 0.045f),
+                )
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.58f, h * 0.10f),
+                    size = Size(w * 0.18f, h * 0.80f),
+                    cornerRadius = CornerRadius(w * 0.045f),
+                )
+            }
+
+            SceneGlyphKind.Backward,
+            SceneGlyphKind.Forward -> {
+                val forward = kind == SceneGlyphKind.Forward
+                fun triangle(x0: Float, x1: Float) {
+                    val p = Path()
+                    if (forward) {
+                        p.moveTo(x0, h * 0.17f)
+                        p.lineTo(x1, h * 0.50f)
+                        p.lineTo(x0, h * 0.83f)
+                    } else {
+                        p.moveTo(x1, h * 0.17f)
+                        p.lineTo(x0, h * 0.50f)
+                        p.lineTo(x1, h * 0.83f)
+                    }
+                    p.close()
+                    drawPath(p, color)
+                }
+                triangle(w * 0.10f, w * 0.50f)
+                triangle(w * 0.45f, w * 0.88f)
+            }
+
+            SceneGlyphKind.SpeakerLow,
+            SceneGlyphKind.SpeakerHigh -> {
+                val speaker = Path().apply {
+                    moveTo(w * 0.08f, h * 0.41f)
+                    lineTo(w * 0.29f, h * 0.41f)
+                    lineTo(w * 0.54f, h * 0.22f)
+                    quadraticBezierTo(w * 0.58f, h * 0.19f, w * 0.58f, h * 0.27f)
+                    lineTo(w * 0.58f, h * 0.73f)
+                    quadraticBezierTo(w * 0.58f, h * 0.81f, w * 0.54f, h * 0.78f)
+                    lineTo(w * 0.29f, h * 0.59f)
+                    lineTo(w * 0.08f, h * 0.59f)
+                    close()
+                }
+                drawPath(speaker, color)
+
+                if (kind == SceneGlyphKind.SpeakerHigh) {
+                    drawArc(
+                        color = color,
+                        startAngle = -46f,
+                        sweepAngle = 92f,
+                        useCenter = false,
+                        topLeft = Offset(w * 0.45f, h * 0.30f),
+                        size = Size(w * 0.30f, h * 0.40f),
+                        style = Stroke(width = stroke, cap = StrokeCap.Round),
+                    )
+                    drawArc(
+                        color = color,
+                        startAngle = -48f,
+                        sweepAngle = 96f,
+                        useCenter = false,
+                        topLeft = Offset(w * 0.43f, h * 0.14f),
+                        size = Size(w * 0.52f, h * 0.72f),
+                        style = Stroke(width = stroke, cap = StrokeCap.Round),
+                    )
+                }
+            }
+
+            SceneGlyphKind.Lyrics -> {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.07f, h * 0.09f),
+                    size = Size(w * 0.86f, h * 0.70f),
+                    cornerRadius = CornerRadius(w * 0.18f),
+                    style = Stroke(width = stroke, cap = StrokeCap.Round),
+                )
+                val tail = Path().apply {
+                    moveTo(w * 0.61f, h * 0.78f)
+                    lineTo(w * 0.52f, h * 0.93f)
+                    lineTo(w * 0.72f, h * 0.79f)
+                }
+                drawPath(tail, color, style = Stroke(width = stroke, cap = StrokeCap.Round))
+
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.28f, h * 0.31f),
+                    size = Size(w * 0.10f, h * 0.18f),
+                    cornerRadius = CornerRadius(w * 0.03f),
+                )
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.53f, h * 0.31f),
+                    size = Size(w * 0.10f, h * 0.18f),
+                    cornerRadius = CornerRadius(w * 0.03f),
+                )
+                drawLine(
+                    color = color,
+                    start = Offset(w * 0.28f, h * 0.49f),
+                    end = Offset(w * 0.23f, h * 0.58f),
+                    strokeWidth = stroke,
+                    cap = StrokeCap.Round,
+                )
+                drawLine(
+                    color = color,
+                    start = Offset(w * 0.53f, h * 0.49f),
+                    end = Offset(w * 0.48f, h * 0.58f),
+                    strokeWidth = stroke,
+                    cap = StrokeCap.Round,
+                )
+            }
+
+            SceneGlyphKind.PipEnter -> {
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.10f, h * 0.12f),
+                    size = Size(w * 0.80f, h * 0.68f),
+                    cornerRadius = CornerRadius(w * 0.10f),
+                    style = Stroke(width = stroke, cap = StrokeCap.Round),
+                )
+                drawRoundRect(
+                    color = color,
+                    topLeft = Offset(w * 0.48f, h * 0.51f),
+                    size = Size(w * 0.38f, h * 0.34f),
+                    cornerRadius = CornerRadius(w * 0.07f),
+                    style = Stroke(width = stroke, cap = StrokeCap.Round),
+                )
+                drawLine(
+                    color = color,
+                    start = Offset(w * 0.29f, h * 0.31f),
+                    end = Offset(w * 0.47f, h * 0.49f),
+                    strokeWidth = stroke,
+                    cap = StrokeCap.Round,
+                )
+                val arrow = Path().apply {
+                    moveTo(w * 0.39f, h * 0.48f)
+                    lineTo(w * 0.49f, h * 0.49f)
+                    lineTo(w * 0.48f, h * 0.39f)
+                }
+                drawPath(arrow, color, style = Stroke(width = stroke, cap = StrokeCap.Round))
+            }
+
+            SceneGlyphKind.Queue -> {
+                listOf(0.27f, 0.50f, 0.73f).forEach { y ->
+                    drawCircle(
+                        color = color,
+                        radius = stroke * 0.72f,
+                        center = Offset(w * 0.17f, h * y),
+                    )
+                    drawLine(
+                        color = color,
+                        start = Offset(w * 0.33f, h * y),
+                        end = Offset(w * 0.88f, h * y),
+                        strokeWidth = stroke,
+                        cap = StrokeCap.Round,
+                    )
+                }
+            }
+
+            SceneGlyphKind.Waveform -> {
+                val xs = listOf(0.18f, 0.38f, 0.60f, 0.82f)
+                val heights = listOf(0.36f, 0.72f, 0.55f, 0.30f)
+                xs.zip(heights).forEach { (x, fraction) ->
+                    val half = h * fraction * 0.5f
+                    drawLine(
+                        color = color,
+                        start = Offset(w * x, h * 0.5f - half),
+                        end = Offset(w * x, h * 0.5f + half),
+                        strokeWidth = stroke,
+                        cap = StrokeCap.Round,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun sceneFormatDuration(milliseconds: Long): String {
+    val seconds = milliseconds.coerceAtLeast(0L) / 1_000L
+    return "%d:%02d".format(seconds / 60L, seconds % 60L)
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXQueuePanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXQueuePanel.kt
@@ -26,13 +26,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.lladlam.melox.ui.glass.meloXLiquidButton
 import androidx.media3.common.Player
+import com.lladlam.melox.ui.glass.meloXLiquidButton
 
 @Composable
 fun MeloXQueuePanel(
     state: MeloXPlaybackUiState,
     modifier: Modifier = Modifier,
+    showSongHeader: Boolean = true,
 ) {
     val currentEntry = state.queue.getOrNull(state.currentIndex)
     val upcoming = if (state.currentIndex >= 0 && state.queue.isNotEmpty()) {
@@ -49,39 +50,50 @@ fun MeloXQueuePanel(
     Column(
         modifier = modifier.padding(top = 8.dp),
     ) {
-        currentEntry?.let { entry ->
-            Row(
+        if (showSongHeader) {
+            currentEntry?.let { entry ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(72.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Artwork(
+                        url = entry.artworkUrl,
+                        modifier = Modifier
+                            .size(68.dp)
+                            .clip(RoundedCornerShape(10.dp)),
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = entry.title,
+                            color = Color.White,
+                            fontSize = 17.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = entry.artist,
+                            color = Color.White.copy(alpha = 0.64f),
+                            fontSize = 14.sp,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(top = 2.dp),
+                        )
+                    }
+                }
+            }
+        } else {
+            // The shared/persistent Now Playing artwork and song header are drawn
+            // above this resident queue page. Keep the reference-height slot so
+            // queue controls and rows retain the same upstream layout geometry.
+            Spacer(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(72.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Artwork(
-                    url = entry.artworkUrl,
-                    modifier = Modifier
-                        .size(68.dp)
-                        .clip(RoundedCornerShape(10.dp)),
-                )
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = entry.title,
-                        color = Color.White,
-                        fontSize = 17.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = entry.artist,
-                        color = Color.White.copy(alpha = 0.64f),
-                        fontSize = 14.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
-                }
-            }
+            )
         }
 
         Spacer(Modifier.height(14.dp))


### PR DESCRIPTION
Rebuilds the portrait Now Playing internals around the upstream MeloX/iOS scene model instead of whole-page AnimatedContent replacement.

Key changes:
- persistent artwork layer moves between the large artwork frame and the shared 72dp Lyrics/Queue song header frame
- Lyrics and Queue use resident-style page timing based on upstream NowPlayingPageTransition constants
- closing from Lyrics/Queue no longer re-enables the full-size artwork destination first
- Lyrics/Queue downward dismissal hands off from nested scrolling only after child scroll reaches its top edge; once collapse starts it remains fully reversible
- player controls remain persistent while pages change
- Now Playing gets isolated backdrop scenes: controls sample flowing-light base, while the actions sheet samples the fully composed player scene
- song actions sheet is moved out of Android Dialog into a same-window overlay so Liquid Glass can blur the actual player beneath it
- queue can reserve its song-header slot while the persistent artwork/header is drawn above it

This deliberately keeps the previous V2 implementation in-tree as a rollback/reference path; SharedHost now uses the new scene.