### PR TITLE
fix: smooth player blur, AutoMix and lyrics

### DIFF
--- a/android/app/src/main/kotlin/com/lladlam/melox/core/download/MeloXDownloadStore.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/download/MeloXDownloadStore.kt
@@ -426,6 +426,19 @@ class MeloXDownloadStore private constructor(private val context: Context) {
                                     )
                                 }
                             },
+                        )
+                        .put(
+                            "romanizationSyllables",
+                            JSONArray().apply {
+                                line.romanizationSyllables.forEach { syllable ->
+                                    put(
+                                        JSONObject()
+                                            .put("text", syllable.text)
+                                            .put("startTimeMs", syllable.startTimeMs)
+                                            .put("endTimeMs", syllable.endTimeMs),
+                                    )
+                                }
+                            },
                         ),
                 )
             }
@@ -450,6 +463,19 @@ class MeloXDownloadStore private constructor(private val context: Context) {
                         )
                     }
                 }
+                val romanizationSyllablesArray = line.optJSONArray("romanizationSyllables") ?: JSONArray()
+                val romanizationSyllables = buildList {
+                    for (s in 0 until romanizationSyllablesArray.length()) {
+                        val item = romanizationSyllablesArray.optJSONObject(s) ?: continue
+                        add(
+                            LyricSyllable(
+                                text = item.optString("text"),
+                                startTimeMs = item.optLong("startTimeMs"),
+                                endTimeMs = item.optLong("endTimeMs"),
+                            ),
+                        )
+                    }
+                }
                 add(
                     LyricLine(
                         timeMs = line.optLong("timeMs"),
@@ -458,6 +484,7 @@ class MeloXDownloadStore private constructor(private val context: Context) {
                         syllables = syllables,
                         translation = line.optString("translation").takeIf(String::isNotBlank),
                         romanization = line.optString("romanization").takeIf(String::isNotBlank),
+                        romanizationSyllables = romanizationSyllables,
                     ),
                 )
             }

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/lyrics/LyricModels.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/lyrics/LyricModels.kt
@@ -16,6 +16,7 @@ data class LyricLine(
     val syllables: List<LyricSyllable> = emptyList(),
     val translation: String? = null,
     val romanization: String? = null,
+    val romanizationSyllables: List<LyricSyllable> = emptyList(),
 )
 
 data class LyricsDocument(
@@ -99,9 +100,12 @@ object NeteaseLyricParser {
 
         return LyricsDocument(
             primary.map { line ->
+                val translationLine = nearestSecondary(line, translated)
+                val romanizationLine = nearestSecondary(line, romanized)
                 line.copy(
-                    translation = nearestSecondary(line, translated),
-                    romanization = nearestSecondary(line, romanized),
+                    translation = annotationText(line, translationLine),
+                    romanization = annotationText(line, romanizationLine),
+                    romanizationSyllables = romanizationLine?.syllables.orEmpty(),
                 )
             },
         )
@@ -193,14 +197,18 @@ object NeteaseLyricParser {
     private fun nearestSecondary(
         target: LyricLine,
         candidates: List<LyricLine>,
-    ): String? {
+    ): LyricLine? {
         if (candidates.isEmpty()) return null
         val candidate = candidates.minByOrNull { kotlin.math.abs(it.timeMs - target.timeMs) }
             ?: return null
         if (kotlin.math.abs(candidate.timeMs - target.timeMs) > ANNOTATION_TOLERANCE_MS) {
             return null
         }
-        val text = candidate.text.trim()
+        return candidate
+    }
+
+    private fun annotationText(target: LyricLine, candidate: LyricLine?): String? {
+        val text = candidate?.text?.trim().orEmpty()
         return text.takeIf { it.isNotBlank() && it != target.text.trim() }
     }
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/lyrics/LyricModels.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/lyrics/LyricModels.kt
@@ -1,5 +1,8 @@
 package com.lladlam.melox.core.lyrics
 
+import java.text.BreakIterator
+import java.util.Locale
+
 data class LyricSyllable(
     val text: String,
     val startTimeMs: Long,
@@ -33,6 +36,45 @@ data class LyricsDocument(
         return (low - 1).takeIf { it >= 0 }
     }
 }
+
+/**
+ * Gives ordinary LRC lines a stable grapheme timeline so the same renderer can
+ * animate both YRC and line-timed lyrics. Real YRC syllables are never replaced.
+ */
+fun LyricsDocument.withPseudoTiming(): LyricsDocument = copy(
+    lines = lines.mapIndexed { index, line ->
+        if (line.syllables.isNotEmpty() || line.text.isBlank()) return@mapIndexed line
+        val iterator = BreakIterator.getCharacterInstance(Locale.ROOT).apply { setText(line.text) }
+        val graphemes = buildList {
+            var start = iterator.first()
+            var end = iterator.next()
+            while (end != BreakIterator.DONE) {
+                add(line.text.substring(start, end))
+                start = end
+                end = iterator.next()
+            }
+        }
+        if (graphemes.isEmpty()) return@mapIndexed line
+        val nextStart = lines.getOrNull(index + 1)?.timeMs
+        val duration = (line.durationMs ?: nextStart?.minus(line.timeMs) ?: 3_000L)
+            .coerceIn(400L, 12_000L)
+        val weights = graphemes.map { if (it.isBlank()) 0.35 else 1.0 }
+        val totalWeight = weights.sum().coerceAtLeast(1.0)
+        var consumed = 0.0
+        line.copy(
+            syllables = graphemes.mapIndexed { graphemeIndex, text ->
+                val startMs = line.timeMs + (duration * consumed / totalWeight).toLong()
+                consumed += weights[graphemeIndex]
+                val endMs = if (graphemeIndex == graphemes.lastIndex) {
+                    line.timeMs + duration
+                } else {
+                    line.timeMs + (duration * consumed / totalWeight).toLong()
+                }
+                LyricSyllable(text, startMs, endMs.coerceAtLeast(startMs + 1L))
+            },
+        )
+    },
+)
 
 object NeteaseLyricParser {
     private const val ANNOTATION_TOLERANCE_MS = 750L

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/lyrics/LyricRomanizationAligner.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/lyrics/LyricRomanizationAligner.kt
@@ -1,0 +1,93 @@
+package com.lladlam.melox.core.lyrics
+
+import java.text.BreakIterator
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+data class LyricRubyUnit(
+    val originalText: String,
+    val originalSyllables: List<LyricSyllable>,
+    val romanizationText: String?,
+)
+
+/** Aligns NetEase yromalrc/romalrc fragments with the primary timed lyric. */
+object LyricRomanizationAligner {
+    fun units(line: LyricLine): List<LyricRubyUnit> {
+        val romanization = line.romanization?.trim().orEmpty()
+        if (romanization.isBlank()) return emptyList()
+
+        timedUnits(line)?.let { return it }
+
+        val tokens = romanization.split(Regex("\\s+")).filter(String::isNotBlank)
+        if (tokens.isNotEmpty() && line.syllables.size == tokens.size) {
+            return line.syllables.zip(tokens) { syllable, token ->
+                LyricRubyUnit(syllable.text, listOf(syllable), token)
+            }
+        }
+
+        val graphemes = graphemes(line.text)
+        val phonetic = graphemes.filterNot(String::isBlank)
+        if (tokens.isNotEmpty() && phonetic.size == tokens.size) {
+            var tokenIndex = 0
+            return graphemes.map { original ->
+                if (original.isBlank()) LyricRubyUnit(original, emptyList(), null)
+                else LyricRubyUnit(original, emptyList(), tokens[tokenIndex++])
+            }
+        }
+
+        return listOf(LyricRubyUnit(line.text, line.syllables, romanization))
+    }
+
+    private fun timedUnits(line: LyricLine): List<LyricRubyUnit>? {
+        val originals = line.syllables.filter { it.text.isNotEmpty() }
+        val romanized = line.romanizationSyllables.filter { it.text.isNotBlank() }
+        if (originals.isEmpty() || romanized.isEmpty()) return null
+
+        if (originals.size == romanized.size) {
+            return originals.zip(romanized) { original, ruby ->
+                LyricRubyUnit(original.text, listOf(original), ruby.text.trim())
+            }
+        }
+
+        val groups = linkedMapOf<Int, MutableList<LyricSyllable>>()
+        originals.forEach { original ->
+            val match = romanized.indices.minByOrNull { temporalDistance(original, romanized[it]) }
+                ?: return@forEach
+            groups.getOrPut(match) { mutableListOf() }.add(original)
+        }
+        val indices = groups.keys.toList()
+        if (indices != indices.sorted() || indices.toSet() != romanized.indices.toSet()) return null
+        return groups.map { (romanizationIndex, originalGroup) ->
+            LyricRubyUnit(
+                originalText = originalGroup.joinToString("") { it.text },
+                originalSyllables = originalGroup,
+                romanizationText = romanized[romanizationIndex].text.trim(),
+            )
+        }
+    }
+
+    private fun temporalDistance(left: LyricSyllable, right: LyricSyllable): Long {
+        val overlap = min(left.endTimeMs, right.endTimeMs) - max(left.startTimeMs, right.startTimeMs)
+        if (overlap >= 0L) {
+            val leftMid = (left.startTimeMs + left.endTimeMs) / 2L
+            val rightMid = (right.startTimeMs + right.endTimeMs) / 2L
+            return abs(leftMid - rightMid) / 6L
+        }
+        return max(left.startTimeMs, right.startTimeMs) - min(left.endTimeMs, right.endTimeMs)
+    }
+
+    private fun graphemes(text: String): List<String> {
+        val iterator = BreakIterator.getCharacterInstance(Locale.ROOT).apply { setText(text) }
+        return buildList {
+            var start = iterator.first()
+            var end = iterator.next()
+            while (end != BreakIterator.DONE) {
+                add(text.substring(start, end))
+                start = end
+                end = iterator.next()
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXAutoMix.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXAutoMix.kt
@@ -1,0 +1,152 @@
+package com.lladlam.melox.playback
+
+import android.content.Context
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+enum class MeloXAutoMixMode { Smart, Fixed }
+enum class MeloXAutoMixFadeCurve { EqualPower, Smooth, Linear }
+enum class MeloXAutoMixFallback { Crossfade, ShortCrossfade, Normal }
+
+data class MeloXAutoMixSettings(
+    val mode: MeloXAutoMixMode = MeloXAutoMixMode.Smart,
+    val transitionBars: Int = 8,
+    val tailCutBars: Int = 4,
+    val fixedDurationMs: Long = 8_000L,
+    val preloadLeadMs: Long = 90_000L,
+    val fadeCurve: MeloXAutoMixFadeCurve = MeloXAutoMixFadeCurve.EqualPower,
+    val tempoMatching: Boolean = true,
+    val maxTempoAdjustment: Double = 0.05,
+    val skipQuietOpening: Boolean = true,
+    val minimumConfidence: Double = 0.42,
+    val analyzeStreaming: Boolean = true,
+    val fallback: MeloXAutoMixFallback = MeloXAutoMixFallback.Crossfade,
+) {
+    companion object {
+        fun read(context: Context): MeloXAutoMixSettings {
+            val prefs = MeloXPlaybackModePreferences.preferences(context)
+            fun <T : Enum<T>> enumValue(key: String, fallback: T, values: Array<T>): T {
+                val stored = prefs.getString(key, fallback.name)
+                return values.firstOrNull { it.name == stored } ?: fallback
+            }
+            return MeloXAutoMixSettings(
+                mode = enumValue("automix_mode", MeloXAutoMixMode.Smart, MeloXAutoMixMode.entries.toTypedArray()),
+                transitionBars = prefs.getInt("automix_transition_bars", 8).coerceIn(4, 16),
+                tailCutBars = prefs.getInt("automix_tail_cut_bars", 4).coerceIn(0, 8),
+                fixedDurationMs = prefs.getLong("automix_fixed_duration_ms", 8_000L).coerceIn(3_000L, 20_000L),
+                preloadLeadMs = prefs.getLong("automix_preload_lead_ms", 90_000L).coerceIn(30_000L, 180_000L),
+                fadeCurve = enumValue("automix_fade_curve", MeloXAutoMixFadeCurve.EqualPower, MeloXAutoMixFadeCurve.entries.toTypedArray()),
+                tempoMatching = prefs.getBoolean("automix_tempo_matching", true),
+                maxTempoAdjustment = prefs.getFloat("automix_max_tempo_adjustment", 0.05f).toDouble().coerceIn(0.01, 0.08),
+                skipQuietOpening = prefs.getBoolean("automix_skip_quiet_opening", true),
+                minimumConfidence = prefs.getFloat("automix_minimum_confidence", 0.42f).toDouble().coerceIn(0.2, 0.8),
+                analyzeStreaming = prefs.getBoolean("automix_analyze_streaming", true),
+                fallback = enumValue("automix_fallback", MeloXAutoMixFallback.Crossfade, MeloXAutoMixFallback.entries.toTypedArray()),
+            )
+        }
+    }
+}
+
+data class MeloXAutoMixAnalysis(
+    val bpm: Double,
+    val confidence: Double,
+    val firstAudibleMs: Long = 0L,
+    val lastAudibleMs: Long? = null,
+)
+
+data class MeloXAutoMixPlan(
+    val durationMs: Long,
+    val incomingStartMs: Long,
+    val outgoingStartRate: Float = 1f,
+    val outgoingEndRate: Float = 1f,
+    val incomingStartRate: Float = 1f,
+    val incomingEndRate: Float = 1f,
+    val usedSmartAnalysis: Boolean = false,
+) {
+    val performsTransition: Boolean get() = durationMs > 0L
+}
+
+/** Pure transition planner ported from MeloX's AutoMixTransitionPlanner. */
+object MeloXAutoMixPlanner {
+    fun plan(
+        settings: MeloXAutoMixSettings,
+        outgoingRemainingMs: Long,
+        outgoing: MeloXAutoMixAnalysis? = null,
+        incoming: MeloXAutoMixAnalysis? = null,
+    ): MeloXAutoMixPlan {
+        if (settings.mode == MeloXAutoMixMode.Fixed) {
+            return fixed(settings.fixedDurationMs, outgoingRemainingMs)
+        }
+        val confident = outgoing != null && incoming != null &&
+            outgoing.confidence >= settings.minimumConfidence &&
+            incoming.confidence >= settings.minimumConfidence &&
+            outgoing.bpm > 0.0 && incoming.bpm > 0.0
+        if (!confident) return fallback(settings, outgoingRemainingMs)
+
+        val beatMs = 60_000.0 / outgoing.bpm
+        val requestedDuration = (settings.transitionBars * 4 * beatMs).toLong()
+        val available = outgoingRemainingMs - HANDOFF_GUARD_MS
+        if (available < MIN_DURATION_MS) return MeloXAutoMixPlan(0L, 0L)
+        val duration = requestedDuration.coerceIn(MIN_DURATION_MS, available)
+        if (duration < MIN_DURATION_MS) return MeloXAutoMixPlan(0L, 0L)
+
+        val incomingStart = if (settings.skipQuietOpening) incoming.firstAudibleMs.coerceAtLeast(0L) else 0L
+        val rates = if (settings.tempoMatching) tempoRates(outgoing.bpm, incoming.bpm, settings.maxTempoAdjustment) else 1f to 1f
+        return MeloXAutoMixPlan(
+            durationMs = duration,
+            incomingStartMs = incomingStart,
+            outgoingStartRate = 1f,
+            outgoingEndRate = rates.first,
+            incomingStartRate = rates.second,
+            incomingEndRate = 1f,
+            usedSmartAnalysis = true,
+        )
+    }
+
+    private fun fallback(settings: MeloXAutoMixSettings, remainingMs: Long): MeloXAutoMixPlan = when (settings.fallback) {
+        MeloXAutoMixFallback.Crossfade -> fixed(settings.fixedDurationMs, remainingMs)
+        MeloXAutoMixFallback.ShortCrossfade -> fixed(3_000L, remainingMs)
+        MeloXAutoMixFallback.Normal -> MeloXAutoMixPlan(0L, 0L)
+    }
+
+    private fun fixed(requestedMs: Long, remainingMs: Long): MeloXAutoMixPlan {
+        val duration = minOf(requestedMs, remainingMs - HANDOFF_GUARD_MS)
+        return if (duration >= MIN_DURATION_MS) MeloXAutoMixPlan(duration, 0L) else MeloXAutoMixPlan(0L, 0L)
+    }
+
+    private fun tempoRates(outgoingBpm: Double, incomingBpm: Double, maxAdjustment: Double): Pair<Float, Float> {
+        val candidates = listOf(incomingBpm / 2.0, incomingBpm, incomingBpm * 2.0)
+        val alignedIncoming = candidates.minByOrNull { kotlin.math.abs(it - outgoingBpm) } ?: incomingBpm
+        val shared = (outgoingBpm + alignedIncoming) / 2.0
+        val outgoingRate = (shared / outgoingBpm).coerceIn(1.0 - maxAdjustment, 1.0 + maxAdjustment)
+        val incomingRate = (shared / alignedIncoming).coerceIn(1.0 - maxAdjustment, 1.0 + maxAdjustment)
+        return outgoingRate.toFloat() to incomingRate.toFloat()
+    }
+
+    const val MIN_DURATION_MS = 1_500L
+    const val HANDOFF_GUARD_MS = 700L
+}
+
+object MeloXAutoMixEnvelope {
+    data class Gains(val outgoing: Float, val incoming: Float)
+
+    fun gains(progress: Double, curve: MeloXAutoMixFadeCurve): Gains {
+        val p = progress.coerceIn(0.0, 1.0)
+        val smooth = p * p * (3.0 - 2.0 * p)
+        return when (curve) {
+            MeloXAutoMixFadeCurve.EqualPower -> Gains(
+                outgoing = cos(smooth * PI / 2.0).toFloat(),
+                incoming = sin(smooth * PI / 2.0).toFloat(),
+            )
+            MeloXAutoMixFadeCurve.Smooth -> Gains((1.0 - smooth).toFloat(), smooth.toFloat())
+            MeloXAutoMixFadeCurve.Linear -> Gains((1.0 - p).toFloat(), p.toFloat())
+        }
+    }
+
+    fun rate(start: Float, end: Float, progress: Double): Float {
+        val p = progress.coerceIn(0.0, 1.0)
+        val smooth = p * p * (3.0 - 2.0 * p)
+        return (start.toDouble() + (end - start).toDouble() * smooth).toFloat()
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXPlaybackModePreferences.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXPlaybackModePreferences.kt
@@ -8,30 +8,53 @@ object MeloXPlaybackModePreferences {
     private const val KEY_AUTOPLAY = "autoplay"
     private const val KEY_AUTOMIX = "auto_mix"
 
-    fun shuffle(context: Context): Boolean =
+    internal fun preferences(context: Context) =
         context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+
+    fun shuffle(context: Context): Boolean =
+        preferences(context)
             .getBoolean(KEY_SHUFFLE, false)
 
     fun autoplay(context: Context): Boolean =
-        context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+        preferences(context)
             .getBoolean(KEY_AUTOPLAY, false)
 
     fun autoMix(context: Context): Boolean =
-        context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+        preferences(context)
             .getBoolean(KEY_AUTOMIX, false)
 
     fun setShuffle(context: Context, enabled: Boolean) {
-        context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+        preferences(context)
             .edit().putBoolean(KEY_SHUFFLE, enabled).apply()
     }
 
     fun setAutoplay(context: Context, enabled: Boolean) {
-        context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+        preferences(context)
             .edit().putBoolean(KEY_AUTOPLAY, enabled).apply()
     }
 
     fun setAutoMix(context: Context, enabled: Boolean) {
-        context.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+        preferences(context)
             .edit().putBoolean(KEY_AUTOMIX, enabled).apply()
+    }
+
+    fun setAutoMixString(context: Context, key: String, value: String) {
+        preferences(context).edit().putString(key, value).apply()
+    }
+
+    fun setAutoMixInt(context: Context, key: String, value: Int) {
+        preferences(context).edit().putInt(key, value).apply()
+    }
+
+    fun setAutoMixLong(context: Context, key: String, value: Long) {
+        preferences(context).edit().putLong(key, value).apply()
+    }
+
+    fun setAutoMixBoolean(context: Context, key: String, value: Boolean) {
+        preferences(context).edit().putBoolean(key, value).apply()
+    }
+
+    fun reset(context: Context) {
+        preferences(context).edit().clear().apply()
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXPlaybackService.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXPlaybackService.kt
@@ -34,6 +34,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
 
 @OptIn(UnstableApi::class)
 class MeloXPlaybackService : MediaSessionService() {
@@ -50,6 +53,9 @@ class MeloXPlaybackService : MediaSessionService() {
     private var mixStartedAt = 0L
     private var mixDurationMs = 0L
     private var mixBaseVolume = 1f
+    private var mixOutgoingStartPositionMs = 0L
+    private var mixIncomingStartPositionMs = 0L
+    private var mixLastProgress = 0.0
 
     private val audioAttributes = AudioAttributes.Builder()
         .setUsage(C.USAGE_MEDIA)
@@ -116,6 +122,23 @@ class MeloXPlaybackService : MediaSessionService() {
                 maybeRunAutoMix(active)
             }
             handler.postDelayed(this, 100L)
+        }
+    }
+
+    /**
+     * Keep the gain envelope independent from the slower queue/autoplay monitor.
+     * Upstream MeloX advances its two-deck envelope every 20 ms; driving volume
+     * from the 100 ms mode monitor made the crossfade audibly step between gains.
+     */
+    private val mixEnvelope = object : Runnable {
+        override fun run() {
+            val active = player
+            val incoming = incomingPlayer
+            if (mixStartedAt == 0L || active == null || incoming == null) return
+            updateAutoMixEnvelope(active, incoming)
+            if (mixStartedAt > 0L) {
+                handler.postDelayed(this, AUTOMIX_ENVELOPE_INTERVAL_MS)
+            }
         }
     }
 
@@ -229,7 +252,7 @@ class MeloXPlaybackService : MediaSessionService() {
 
     private fun maybeRunAutoMix(active: ExoPlayer) {
         if (!MeloXPlaybackModePreferences.autoMix(this)) {
-            cancelPreparedMix()
+            cancelPreparedMix(releaseStandby = true)
             return
         }
         if (!active.isPlaying || active.repeatMode == Player.REPEAT_MODE_ONE || !active.hasNextMediaItem()) return
@@ -237,7 +260,7 @@ class MeloXPlaybackService : MediaSessionService() {
         val duration = active.duration.takeIf { it != C.TIME_UNSET && it > 0L } ?: return
         val remaining = duration - active.currentPosition
         val sourceId = active.currentMediaItem?.mediaId ?: return
-        if (incomingPlayer == null && remaining <= AUTOMIX_PRELOAD_MS) {
+        if (preparedMixSourceId == null && remaining <= AUTOMIX_PRELOAD_MS) {
             prepareIncoming(active, sourceId)
         }
         val incoming = incomingPlayer ?: return
@@ -254,16 +277,43 @@ class MeloXPlaybackService : MediaSessionService() {
             incoming.volume = 0f
             incoming.play()
             mixStartedAt = SystemClock.elapsedRealtime()
+            mixOutgoingStartPositionMs = active.currentPosition.coerceAtLeast(0L)
+            mixIncomingStartPositionMs = incoming.currentPosition.coerceAtLeast(0L)
+            mixLastProgress = 0.0
+            handler.removeCallbacks(mixEnvelope)
+            handler.post(mixEnvelope)
         }
-        if (mixStartedAt > 0L) {
-            val elapsed = SystemClock.elapsedRealtime() - mixStartedAt
-            val durationMs = mixDurationMs.coerceAtLeast(1L)
-            val progress = (elapsed.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
-            active.volume = mixBaseVolume * (1f - progress)
-            incoming.volume = mixBaseVolume * progress
-            if (progress >= 1f || remaining <= AUTOMIX_HANDOFF_GUARD_MS) {
-                completeAutoMix(active, incoming)
-            }
+    }
+
+    private fun updateAutoMixEnvelope(active: ExoPlayer, incoming: ExoPlayer) {
+        val duration = active.duration.takeIf { it != C.TIME_UNSET && it > 0L }
+        val remaining = duration?.minus(active.currentPosition) ?: Long.MAX_VALUE
+        val durationMs = mixDurationMs.coerceAtLeast(1L)
+        // Drive the envelope from both decks' rendered media clocks, matching
+        // upstream MeloX. This prevents the fade from running ahead while the
+        // incoming decoder is technically READY but has not advanced audio yet.
+        val outgoingProgress =
+            (active.currentPosition - mixOutgoingStartPositionMs).coerceAtLeast(0L).toDouble() /
+                durationMs.toDouble()
+        val incomingProgress =
+            (incoming.currentPosition - mixIncomingStartPositionMs).coerceAtLeast(0L).toDouble() /
+                durationMs.toDouble()
+        val progress = maxOf(
+            mixLastProgress,
+            minOf(outgoingProgress, incomingProgress),
+        ).coerceIn(0.0, 1.0)
+        mixLastProgress = progress
+
+        // Match MeloX AutoMixFadeEnvelope.equalPower: smoothstep timing avoids a
+        // derivative jump, while sin/cos gains avoid the perceived midpoint dip.
+        val smoothed = progress * progress * (3.0 - 2.0 * progress)
+        val outgoingGain = cos(smoothed * PI / 2.0).toFloat()
+        val incomingGain = sin(smoothed * PI / 2.0).toFloat()
+        active.volume = mixBaseVolume * outgoingGain
+        incoming.volume = mixBaseVolume * incomingGain
+
+        if (progress >= 1.0 || remaining <= AUTOMIX_HANDOFF_GUARD_MS) {
+            completeAutoMix(active, incoming)
         }
     }
 
@@ -277,7 +327,16 @@ class MeloXPlaybackService : MediaSessionService() {
         ) {
             return
         }
-        val incoming = buildPlayer(managesAudioFocus = false, observesSession = false)
+        // Reuse the inactive deck just like upstream MeloX. Constructing and
+        // releasing ExoPlayer at every handoff adds avoidable work at song edges.
+        val incoming = incomingPlayer ?: buildPlayer(
+            managesAudioFocus = false,
+            observesSession = false,
+        )
+        incoming.stop()
+        incoming.clearMediaItems()
+        incoming.setAudioAttributes(audioAttributes, false)
+        incoming.setHandleAudioBecomingNoisy(false)
         val items = List(active.mediaItemCount) { active.getMediaItemAt(it) }
         incoming.setMediaItems(items, nextIndex, 0L)
         incoming.volume = 0f
@@ -293,6 +352,7 @@ class MeloXPlaybackService : MediaSessionService() {
      * forward/backward jump reported at the outgoing song's original endpoint.
      */
     private fun completeAutoMix(old: ExoPlayer, incoming: ExoPlayer) {
+        handler.removeCallbacks(mixEnvelope)
         old.volume = 0f
         incoming.volume = mixBaseVolume
         incoming.setAudioAttributes(audioAttributes, true)
@@ -300,13 +360,20 @@ class MeloXPlaybackService : MediaSessionService() {
         incoming.addListener(playerListener)
         mediaSession?.setPlayer(incoming)
         player = incoming
-        incomingPlayer = null
         preparedMixSourceId = null
         mixStartedAt = 0L
         mixDurationMs = 0L
+        mixOutgoingStartPositionMs = 0L
+        mixIncomingStartPositionMs = 0L
+        mixLastProgress = 0.0
         old.removeListener(playerListener)
         old.pause()
-        old.release()
+        old.stop()
+        old.clearMediaItems()
+        old.setAudioAttributes(audioAttributes, false)
+        old.setHandleAudioBecomingNoisy(false)
+        old.volume = 0f
+        incomingPlayer = old
         applyLocalArtworkMetadata(incoming)
     }
 
@@ -346,18 +413,25 @@ class MeloXPlaybackService : MediaSessionService() {
         return true
     }
 
-    private fun cancelPreparedMix() {
+    private fun cancelPreparedMix(releaseStandby: Boolean = false) {
+        handler.removeCallbacks(mixEnvelope)
         val active = player
         if (mixStartedAt > 0L && active != null) active.volume = mixBaseVolume
         incomingPlayer?.run {
             removeListener(playerListener)
             pause()
-            release()
+            stop()
+            clearMediaItems()
+            volume = 0f
+            if (releaseStandby) release()
         }
-        incomingPlayer = null
+        if (releaseStandby) incomingPlayer = null
         preparedMixSourceId = null
         mixStartedAt = 0L
         mixDurationMs = 0L
+        mixOutgoingStartPositionMs = 0L
+        mixIncomingStartPositionMs = 0L
+        mixLastProgress = 0.0
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
@@ -369,7 +443,7 @@ class MeloXPlaybackService : MediaSessionService() {
         handler.removeCallbacks(modeMonitor)
         recommendationJob?.cancel()
         serviceScope.cancel()
-        cancelPreparedMix()
+        cancelPreparedMix(releaseStandby = true)
         mediaSession?.release()
         mediaSession = null
         player?.removeListener(playerListener)
@@ -385,5 +459,6 @@ class MeloXPlaybackService : MediaSessionService() {
         const val AUTOMIX_DURATION_MS = 6_000L
         const val MIN_AUTOMIX_DURATION_MS = 1_500L
         const val AUTOMIX_HANDOFF_GUARD_MS = 700L
+        const val AUTOMIX_ENVELOPE_INTERVAL_MS = 20L
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXPlaybackService.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/playback/MeloXPlaybackService.kt
@@ -34,9 +34,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.math.PI
-import kotlin.math.cos
-import kotlin.math.sin
 
 @OptIn(UnstableApi::class)
 class MeloXPlaybackService : MediaSessionService() {
@@ -56,6 +53,8 @@ class MeloXPlaybackService : MediaSessionService() {
     private var mixOutgoingStartPositionMs = 0L
     private var mixIncomingStartPositionMs = 0L
     private var mixLastProgress = 0.0
+    private var mixSettings = MeloXAutoMixSettings()
+    private var mixPlan = MeloXAutoMixPlan(0L, 0L)
 
     private val audioAttributes = AudioAttributes.Builder()
         .setUsage(C.USAGE_MEDIA)
@@ -260,7 +259,8 @@ class MeloXPlaybackService : MediaSessionService() {
         val duration = active.duration.takeIf { it != C.TIME_UNSET && it > 0L } ?: return
         val remaining = duration - active.currentPosition
         val sourceId = active.currentMediaItem?.mediaId ?: return
-        if (preparedMixSourceId == null && remaining <= AUTOMIX_PRELOAD_MS) {
+        val settings = MeloXAutoMixSettings.read(this)
+        if (preparedMixSourceId == null && remaining <= settings.preloadLeadMs) {
             prepareIncoming(active, sourceId)
         }
         val incoming = incomingPlayer ?: return
@@ -268,12 +268,21 @@ class MeloXPlaybackService : MediaSessionService() {
             if (mixStartedAt > 0L) completeAutoMix(active, incoming) else cancelPreparedMix()
             return
         }
-        if (mixStartedAt == 0L && incoming.playbackState == Player.STATE_READY && remaining <= AUTOMIX_DURATION_MS) {
-            mixBaseVolume = active.volume.coerceIn(0f, 1f)
-            mixDurationMs = minOf(
-                AUTOMIX_DURATION_MS,
-                (remaining - AUTOMIX_HANDOFF_GUARD_MS).coerceAtLeast(MIN_AUTOMIX_DURATION_MS),
+        val candidate = MeloXAutoMixPlanner.plan(settings, Long.MAX_VALUE / 4L)
+        if (!candidate.performsTransition) return
+        if (mixStartedAt == 0L && incoming.playbackState == Player.STATE_READY && remaining <= candidate.durationMs) {
+            val actualDuration = minOf(
+                candidate.durationMs,
+                remaining - MeloXAutoMixPlanner.HANDOFF_GUARD_MS,
             )
+            if (actualDuration < MeloXAutoMixPlanner.MIN_DURATION_MS) return
+            mixSettings = settings
+            mixPlan = candidate.copy(durationMs = actualDuration)
+            mixBaseVolume = active.volume.coerceIn(0f, 1f)
+            mixDurationMs = actualDuration
+            if (candidate.incomingStartMs > 0L) incoming.seekTo(candidate.incomingStartMs)
+            active.setPlaybackSpeed(candidate.outgoingStartRate)
+            incoming.setPlaybackSpeed(candidate.incomingStartRate)
             incoming.volume = 0f
             incoming.play()
             mixStartedAt = SystemClock.elapsedRealtime()
@@ -304,15 +313,17 @@ class MeloXPlaybackService : MediaSessionService() {
         ).coerceIn(0.0, 1.0)
         mixLastProgress = progress
 
-        // Match MeloX AutoMixFadeEnvelope.equalPower: smoothstep timing avoids a
-        // derivative jump, while sin/cos gains avoid the perceived midpoint dip.
-        val smoothed = progress * progress * (3.0 - 2.0 * progress)
-        val outgoingGain = cos(smoothed * PI / 2.0).toFloat()
-        val incomingGain = sin(smoothed * PI / 2.0).toFloat()
-        active.volume = mixBaseVolume * outgoingGain
-        incoming.volume = mixBaseVolume * incomingGain
+        val gains = MeloXAutoMixEnvelope.gains(progress, mixSettings.fadeCurve)
+        active.volume = mixBaseVolume * gains.outgoing
+        incoming.volume = mixBaseVolume * gains.incoming
+        active.setPlaybackSpeed(
+            MeloXAutoMixEnvelope.rate(mixPlan.outgoingStartRate, mixPlan.outgoingEndRate, progress),
+        )
+        incoming.setPlaybackSpeed(
+            MeloXAutoMixEnvelope.rate(mixPlan.incomingStartRate, mixPlan.incomingEndRate, progress),
+        )
 
-        if (progress >= 1.0 || remaining <= AUTOMIX_HANDOFF_GUARD_MS) {
+        if (progress >= 1.0 || remaining <= MeloXAutoMixPlanner.HANDOFF_GUARD_MS) {
             completeAutoMix(active, incoming)
         }
     }
@@ -355,6 +366,7 @@ class MeloXPlaybackService : MediaSessionService() {
         handler.removeCallbacks(mixEnvelope)
         old.volume = 0f
         incoming.volume = mixBaseVolume
+        incoming.setPlaybackSpeed(1f)
         incoming.setAudioAttributes(audioAttributes, true)
         incoming.setHandleAudioBecomingNoisy(true)
         incoming.addListener(playerListener)
@@ -372,6 +384,7 @@ class MeloXPlaybackService : MediaSessionService() {
         old.clearMediaItems()
         old.setAudioAttributes(audioAttributes, false)
         old.setHandleAudioBecomingNoisy(false)
+        old.setPlaybackSpeed(1f)
         old.volume = 0f
         incomingPlayer = old
         applyLocalArtworkMetadata(incoming)
@@ -416,13 +429,17 @@ class MeloXPlaybackService : MediaSessionService() {
     private fun cancelPreparedMix(releaseStandby: Boolean = false) {
         handler.removeCallbacks(mixEnvelope)
         val active = player
-        if (mixStartedAt > 0L && active != null) active.volume = mixBaseVolume
+        if (mixStartedAt > 0L && active != null) {
+            active.volume = mixBaseVolume
+            active.setPlaybackSpeed(1f)
+        }
         incomingPlayer?.run {
             removeListener(playerListener)
             pause()
             stop()
             clearMediaItems()
             volume = 0f
+            setPlaybackSpeed(1f)
             if (releaseStandby) release()
         }
         if (releaseStandby) incomingPlayer = null
@@ -432,6 +449,8 @@ class MeloXPlaybackService : MediaSessionService() {
         mixOutgoingStartPositionMs = 0L
         mixIncomingStartPositionMs = 0L
         mixLastProgress = 0.0
+        mixSettings = MeloXAutoMixSettings()
+        mixPlan = MeloXAutoMixPlan(0L, 0L)
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
@@ -455,10 +474,6 @@ class MeloXPlaybackService : MediaSessionService() {
     private companion object {
         const val TAG = "MeloXPlayback"
         const val AUTOPLAY_PRELOAD_MS = 15_000L
-        const val AUTOMIX_PRELOAD_MS = 10_000L
-        const val AUTOMIX_DURATION_MS = 6_000L
-        const val MIN_AUTOMIX_DURATION_MS = 1_500L
-        const val AUTOMIX_HANDOFF_GUARD_MS = 700L
         const val AUTOMIX_ENVELOPE_INTERVAL_MS = 20L
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/MeloXApp.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -90,6 +91,8 @@ import com.lladlam.melox.ui.player.rememberMeloXPlaybackUiState
 import com.lladlam.melox.ui.search.SearchScreen
 import com.lladlam.melox.ui.search.MeloXSearchLaunchBus
 import com.lladlam.melox.ui.settings.SettingsScreen
+import com.lladlam.melox.ui.settings.MeloXSettingsPreferences
+import com.lladlam.melox.ui.settings.MeloXSettingsRuntime
 import com.lladlam.melox.core.network.MeloXSearchKind
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -109,7 +112,11 @@ private val MeloXAccent = Color(0xFFFF3147)
 fun MeloXApp(
     openNowPlayingRequest: Int = 0,
 ) {
-    var selectedTab by remember { mutableStateOf(AppTab.Home) }
+    val context = LocalContext.current.applicationContext
+    val initialTab = if (MeloXSettingsRuntime.rememberLastTab) runCatching {
+        AppTab.valueOf(MeloXSettingsPreferences.string(context, "general_last_tab", AppTab.Home.name))
+    }.getOrDefault(AppTab.Home) else AppTab.Home
+    var selectedTab by remember { mutableStateOf(initialTab) }
     var showNeteaseLogin by remember { mutableStateOf(false) }
     var loginReturnTab by remember { mutableStateOf(AppTab.Settings) }
     var tabBarMinimized by remember { mutableStateOf(false) }
@@ -210,6 +217,21 @@ fun MeloXApp(
         tabBarMinimized = false
         scrollAccumulator = 0f
         if (selectedTab != AppTab.Library) libraryModalVisible = false
+        if (MeloXSettingsRuntime.rememberLastTab) {
+            MeloXSettingsPreferences.setString(context, "general_last_tab", selectedTab.name)
+        }
+    }
+
+    val visibleRootTabs = buildList {
+        if (MeloXSettingsRuntime.homeTabEnabled) add(AppTab.Home)
+        if (MeloXSettingsRuntime.exploreTabEnabled) add(AppTab.Explore)
+        if (MeloXSettingsRuntime.libraryTabEnabled) add(AppTab.Library)
+        add(AppTab.Settings)
+    }
+    LaunchedEffect(visibleRootTabs, selectedTab) {
+        if (selectedTab !in visibleRootTabs && selectedTab != AppTab.Search) {
+            selectedTab = visibleRootTabs.first()
+        }
     }
 
     CompositionLocalProvider(LocalMeloXBackdrop provides screenControlBackdrop) {
@@ -269,6 +291,7 @@ fun MeloXApp(
                     },
                     hasMedia = playbackState.hasMedia,
                     minimized = tabBarMinimized,
+                    visibleRootTabs = visibleRootTabs,
                     modifier = Modifier.align(Alignment.BottomCenter),
                     miniPlayer = { compactProgress ->
                         playerTransition.AnimatedVisibility(
@@ -388,6 +411,7 @@ private fun MeloXBottomChrome(
     onSelect: (AppTab) -> Unit,
     hasMedia: Boolean,
     minimized: Boolean,
+    visibleRootTabs: List<AppTab>,
     modifier: Modifier = Modifier,
     miniPlayer: @Composable (compactProgress: Float) -> Unit,
 ) {
@@ -439,7 +463,7 @@ private fun MeloXBottomChrome(
                 AppTab.Explore to RootGlyph.Explore,
                 AppTab.Library to RootGlyph.Library,
                 AppTab.Settings to RootGlyph.Settings,
-            )
+            ).filter { it.first in visibleRootTabs }
 
             val desiredCompactMiniVisibleWidth =
                 (maxWidth - horizontalMargin * 2 - compactSize * 2 - compactGap * 2)
@@ -491,8 +515,9 @@ private fun MeloXBottomChrome(
                     .pointerInput(progress, selectedTab) {
                         detectTapGestures { tap ->
                             if (progress < 0.56f) {
-                                val segmentWidth = size.width / 4f
-                                val index = (tap.x / segmentWidth).toInt().coerceIn(0, 3)
+                                val segmentWidth = size.width / primaryTabs.size.coerceAtLeast(1).toFloat()
+                                val index = (tap.x / segmentWidth).toInt()
+                                    .coerceIn(0, primaryTabs.lastIndex.coerceAtLeast(0))
                                 onSelect(primaryTabs[index].first)
                             } else if (progress >= 0.68f) {
                                 onSelect(selectedTab)
@@ -505,8 +530,9 @@ private fun MeloXBottomChrome(
                 val selectionEdgeInset = 5.dp
                 val selectionEdgeInsetPx = with(density) { selectionEdgeInset.toPx() }
                 val selectionTravelWidthPx = (tabBarMaxWidthPx - selectionEdgeInsetPx * 2f).coerceAtLeast(1f)
-                val selectionSegmentPx = selectionTravelWidthPx / 4f
-                val selectionWidth = (maxWidth - selectionEdgeInset * 2f) / 4f
+                val tabCount = primaryTabs.size.coerceAtLeast(1)
+                val selectionSegmentPx = selectionTravelWidthPx / tabCount.toFloat()
+                val selectionWidth = (maxWidth - selectionEdgeInset * 2f) / tabCount.toFloat()
                 Box(Modifier.fillMaxSize()) {
                     Row(
                         modifier = Modifier

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXBackdropComponents.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/glass/MeloXBackdropComponents.kt
@@ -107,6 +107,7 @@ fun Modifier.meloXLiquidBottomBar(
     shape: Shape,
     tint: Color,
     surfaceColor: Color,
+    blurRadius: Dp = 8.dp,
 ): Modifier {
     val backdrop = LocalMeloXBackdrop.current
     if (backdrop == null) {
@@ -119,7 +120,7 @@ fun Modifier.meloXLiquidBottomBar(
         shape = { shape },
         effects = {
             vibrancy()
-            blur(8.dp.toPx())
+            blur(blurRadius.toPx())
             lens(24.dp.toPx(), 24.dp.toPx(), chromaticAberration = false)
         },
         onDrawSurface = {

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.sp
 import com.lladlam.melox.core.account.NeteaseSessionStore
 import com.lladlam.melox.core.lyrics.LyricLine
 import com.lladlam.melox.core.lyrics.LyricsDocument
+import com.lladlam.melox.core.lyrics.withPseudoTiming
 import com.lladlam.melox.core.download.MeloXDownloadStore
 import com.lladlam.melox.core.network.NeteaseSearchClient
 import com.lladlam.melox.ui.settings.MeloXSettingsRuntime
@@ -84,7 +85,9 @@ import kotlin.math.sqrt
  * Keep source constants here instead of "tuning by eye".  The rendering backend
  * is Compose rather than SwiftUI, but focus geometry, timing, dim/blur equations,
  * 120 ms colour hand-off, promoted current-line layout and cascade scheduling are
- * intentionally kept numerically identical to upstream MeloX.
+ * follows upstream MeloX. Cascade timing is shortened for Android's frame and
+ * blur cost so quick consecutive lines do not leave several row animations in
+ * flight at the same time.
  */
 private object UpstreamLyrics {
     const val FONT_SIZE_SP = 34f
@@ -101,17 +104,17 @@ private object UpstreamLyrics {
     const val ANNOTATION_SPACING_DP = 4f
     const val FOCUS_COLOR_DURATION_MS = 120
 
-    const val CASCADE_DELAY_MS = 21f
-    const val CASCADE_DELAY_INCREASE_MS = 5f
-    const val CASCADE_FOLLOWING_DELAY_MS = 30f
+    const val CASCADE_DELAY_MS = 14f
+    const val CASCADE_DELAY_INCREASE_MS = 2.5f
+    const val CASCADE_FOLLOWING_DELAY_MS = 22f
     const val CASCADE_CATCH_UP_RATIO = 0.97f
-    const val CASCADE_CHASE_SPEED_GRADIENT = 0.70f
-    const val CASCADE_DURATION_MS = 740f
-    const val CASCADE_SNAP_THRESHOLD_MS = 260f
-    const val CASCADE_BOUNCE = 0.26f
-    const val CASCADE_BOUNCE_GRADIENT = 0.85f
-    const val SCALE_BOUNCE = 0.32f
-    const val SCALE_BOUNCE_DURATION_MS = 580
+    const val CASCADE_CHASE_SPEED_GRADIENT = 0.82f
+    const val CASCADE_DURATION_MS = 560f
+    const val CASCADE_SNAP_THRESHOLD_MS = 180f
+    const val CASCADE_BOUNCE = 0.14f
+    const val CASCADE_BOUNCE_GRADIENT = 0.60f
+    const val SCALE_BOUNCE = 0.16f
+    const val SCALE_BOUNCE_DURATION_MS = 420
 
     const val GLOW_INTENSITY = 1f
     const val LONG_TONE_THRESHOLD_MS = 950f
@@ -124,8 +127,6 @@ private object UpstreamLyrics {
     const val MIN_UNPLAYED_BLUR_FRACTION = 0.12f
     const val LIFT_CONTINUATION_MS = 320f
 
-    const val FOLLOW_DELAY_MS = 3000L
-    const val NON_YRC_ADVANCE_MS = 200L
 }
 
 @Composable
@@ -174,18 +175,23 @@ fun MeloXIOSLyricsPanel(
     }
 
     val document = lyrics
-    val lines = document?.lines.orEmpty()
-    val hasSyllableSync = remember(document) { lines.any { it.syllables.isNotEmpty() } }
+    val pseudoTimingEnabled = MeloXSettingsRuntime.lyricPseudoTimingEnabled
+    val renderedDocument = remember(document, pseudoTimingEnabled) {
+        if (pseudoTimingEnabled) document?.withPseudoTiming() else document
+    }
+    val lines = renderedDocument?.lines.orEmpty()
+    val hasSyllableSync = remember(renderedDocument) { lines.any { it.syllables.isNotEmpty() } }
+    val lyricAdvanceMs = MeloXSettingsRuntime.lyricAdvanceMs.toLong()
     var highlightedIndex by remember(document) {
         mutableIntStateOf(
             sourceHighlightedIndex(
                 lines,
-                state.positionMs + if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS,
+                state.positionMs + lyricAdvanceMs,
             ),
         )
     }
-    val playbackTimeProvider = remember(mediaId) {
-        { renderedPositionState.longValue }
+    val playbackTimeProvider = remember(mediaId, lyricAdvanceMs) {
+        { renderedPositionState.longValue + lyricAdvanceMs }
     }
 
     // Update the line index only when it actually changes. The per-frame time is
@@ -199,8 +205,7 @@ fun MeloXIOSLyricsPanel(
                 anchorPositionMs
             }
             renderedPositionState.longValue = position
-            val effectivePosition = position +
-                if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS
+            val effectivePosition = position + lyricAdvanceMs
             val nextIndex = sourceHighlightedIndex(lines, effectivePosition)
             if (nextIndex != highlightedIndex) highlightedIndex = nextIndex
             if (state.isPlaying) withFrameNanos { } else delay(200L)
@@ -224,7 +229,13 @@ fun MeloXIOSLyricsPanel(
     var cascadeDestinationOffsets by remember(document) {
         mutableStateOf<Map<Int, Float>>(emptyMap())
     }
-    val rowHeightsPx = remember(document) { mutableStateMapOf<Int, Int>() }
+    val rowHeightsPx = remember(
+        document,
+        MeloXSettingsRuntime.lyricFontScale,
+        MeloXSettingsRuntime.lyricSpacingScale,
+        MeloXSettingsRuntime.showLyricTranslation,
+        MeloXSettingsRuntime.showLyricRomanization,
+    ) { mutableStateMapOf<Int, Int>() }
     var viewportHeightPx by remember(document) { mutableIntStateOf(0) }
     var visualFocusIndex by remember(document) { mutableIntStateOf(-1) }
     var isBrowsingLyrics by remember(document) { mutableStateOf(false) }
@@ -235,10 +246,12 @@ fun MeloXIOSLyricsPanel(
     val latestVisibilityCallback = rememberUpdatedState(onInterfaceVisibilityChange)
     val latestInteractionCallback = rememberUpdatedState(onInterfaceInteraction)
 
-    val lineSpacingPx = with(density) { UpstreamLyrics.LINE_SPACING_DP.dp.toPx() }
-    val primaryHeightPx = with(density) { UpstreamLyrics.LINE_HEIGHT_SP.sp.toPx() }
+    val lyricFontScale = MeloXSettingsRuntime.lyricFontScale
+    val lyricSpacingScale = MeloXSettingsRuntime.lyricSpacingScale
+    val lineSpacingPx = with(density) { (UpstreamLyrics.LINE_SPACING_DP * lyricSpacingScale).dp.toPx() }
+    val primaryHeightPx = with(density) { (UpstreamLyrics.LINE_HEIGHT_SP * lyricFontScale).sp.toPx() }
     val annotationFontPx = with(density) {
-        max(UpstreamLyrics.FONT_SIZE_SP * UpstreamLyrics.ROMANIZATION_FONT_SCALE, 13f).sp.toPx()
+        max(UpstreamLyrics.FONT_SIZE_SP * lyricFontScale * UpstreamLyrics.ROMANIZATION_FONT_SCALE, 13f).sp.toPx()
     }
     val annotationSpacingPx = with(density) { UpstreamLyrics.ANNOTATION_SPACING_DP.dp.toPx() }
 
@@ -291,7 +304,8 @@ fun MeloXIOSLyricsPanel(
             val target = if (index == nextIndex) 1f else 0f
             if (abs(anim.value - target) > 0.0001f) {
                 launch {
-                    anim.animateTo(
+                    if (MeloXSettingsRuntime.lyricReduceMotion) anim.snapTo(target)
+                    else anim.animateTo(
                         targetValue = target,
                         animationSpec = tween(
                             durationMillis = UpstreamLyrics.FOCUS_COLOR_DURATION_MS,
@@ -304,6 +318,10 @@ fun MeloXIOSLyricsPanel(
     }
 
     suspend fun handOffFocusScale(previousIndex: Int, nextIndex: Int) = coroutineScope {
+        if (MeloXSettingsRuntime.lyricReduceMotion) {
+            scaleProgress.forEachIndexed { index, anim -> anim.snapTo(if (index == nextIndex) 1f else 0f) }
+            return@coroutineScope
+        }
         if (previousIndex in scaleProgress.indices && previousIndex != nextIndex) {
             launch {
                 scaleProgress[previousIndex].animateTo(
@@ -367,7 +385,7 @@ fun MeloXIOSLyricsPanel(
 
     LaunchedEffect(browseGeneration, document) {
         if (browseGeneration <= 0) return@LaunchedEffect
-        delay(UpstreamLyrics.FOLLOW_DELAY_MS)
+        delay(MeloXSettingsRuntime.lyricFollowDelayMs.toLong())
         isBrowsingLyrics = false
         playbackFocusGeneration += 1
     }
@@ -434,10 +452,24 @@ fun MeloXIOSLyricsPanel(
                 return@LaunchedEffect
             }
 
+            if (!MeloXSettingsRuntime.lyricAutoFollowEnabled) {
+                handOffFocusColor(nextIndex)
+                handOffFocusScale(previousIndex, nextIndex)
+                visualFocusIndex = nextIndex
+                return@LaunchedEffect
+            }
+
+            if (MeloXSettingsRuntime.lyricReduceMotion) {
+                clearCascadePresentation(nextIndex)
+                handOffFocusColor(nextIndex)
+                handOffFocusScale(previousIndex, nextIndex)
+                listState.scrollToItem(nextIndex + 1, targetOffset)
+                return@LaunchedEffect
+            }
+
             val baseDurationMs = sourceFocusAnimationDurationMs(nextIndex, lines)
             val isAdjacentForward = nextIndex == previousIndex + 1
-            val effectivePosition = renderedPositionState.longValue +
-                if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS
+            val effectivePosition = renderedPositionState.longValue + lyricAdvanceMs
             val remainingMs = sourceRemainingFocusDurationMs(nextIndex, effectivePosition, lines)
 
             val fullCascadeMs = max(baseDurationMs.toFloat(), UpstreamLyrics.CASCADE_DURATION_MS)
@@ -626,13 +658,14 @@ fun MeloXIOSLyricsPanel(
                         val distanceBlur = sourceDistanceBlurRadius(
                             distancePx = distance,
                             lyricStridePx = lyricStridePx,
-                            intensity = UpstreamLyrics.BLUR_INTENSITY * UpstreamLyrics.DISTANCE_BLUR_SCALE,
+                            intensity = UpstreamLyrics.BLUR_INTENSITY * UpstreamLyrics.DISTANCE_BLUR_SCALE *
+                                MeloXSettingsRuntime.lyricBlurStrength,
                             focusProgress = effectiveFocus,
                         )
                         val preceding = index == visualFocusIndex - 1
                         val following = index == visualFocusIndex + 1
                         val focusBlur = sourceFocusBlurRadius(
-                            UpstreamLyrics.BLUR_INTENSITY,
+                            UpstreamLyrics.BLUR_INTENSITY * MeloXSettingsRuntime.lyricBlurStrength,
                             preceding,
                             following,
                         ) * (1f - effectiveFocus)
@@ -656,7 +689,10 @@ fun MeloXIOSLyricsPanel(
                         MeloXUpstreamLyricLine(
                             line = line,
                             playbackTimeProvider = playbackTimeProvider,
-                            supportsTimedLyrics = line.syllables.isNotEmpty(),
+                            supportsTimedLyrics = line.syllables.isNotEmpty() &&
+                                MeloXSettingsRuntime.lyricWordByWordEnabled,
+                            fontScale = lyricFontScale,
+                            reduceMotion = MeloXSettingsRuntime.lyricReduceMotion,
                             focusProgress = effectiveFocus,
                             visualScale = scale,
                             visualOffsetPx = visualOffset,
@@ -674,11 +710,12 @@ fun MeloXIOSLyricsPanel(
                                     rowHeightsPx[index] = measured
                                 }
                             },
+                            tapSeekEnabled = MeloXSettingsRuntime.lyricTapSeekEnabled,
                             onClick = { onInterfaceInteraction(); state.seekTo(line.timeMs) },
                         )
 
                         if (index != lines.lastIndex) {
-                            Spacer(Modifier.height(UpstreamLyrics.LINE_SPACING_DP.dp))
+                            Spacer(Modifier.height((UpstreamLyrics.LINE_SPACING_DP * lyricSpacingScale).dp))
                         }
                     }
                     item(key = "lyrics-bottom-padding") {
@@ -695,6 +732,8 @@ private fun MeloXUpstreamLyricLine(
     line: LyricLine,
     playbackTimeProvider: () -> Long,
     supportsTimedLyrics: Boolean,
+    fontScale: Float,
+    reduceMotion: Boolean,
     focusProgress: Float,
     visualScale: Float,
     visualOffsetPx: Float,
@@ -705,18 +744,16 @@ private fun MeloXUpstreamLyricLine(
     showRomanization: Boolean,
     reserveTranslation: Boolean,
     reserveRomanization: Boolean,
+    tapSeekEnabled: Boolean,
     onMeasured: (Int) -> Unit,
     onClick: () -> Unit,
 ) {
-    val blurModifier = Modifier
-        .blur(
-            radius = max(distanceBlurDp, 0f).dp,
-            edgeTreatment = BlurredEdgeTreatment.Unbounded,
-        )
-        .blur(
-            radius = max(focusBlurDp, 0f).dp,
-            edgeTreatment = BlurredEdgeTreatment.Unbounded,
-        )
+    // One blur layer is materially cheaper than stacking distance and focus
+    // blurs on every visible row, and removes a common source of scroll jank.
+    val blurModifier = Modifier.blur(
+        radius = max(max(distanceBlurDp, focusBlurDp), 0f).dp,
+        edgeTreatment = BlurredEdgeTreatment.Unbounded,
+    )
 
     Column(
         modifier = Modifier
@@ -730,7 +767,7 @@ private fun MeloXUpstreamLyricLine(
                 transformOrigin = TransformOrigin(0f, 0f)
             }
             .then(blurModifier)
-            .clickable(onClick = onClick)
+            .clickable(enabled = tapSeekEnabled, onClick = onClick)
             .padding(horizontal = 8.dp),
         horizontalAlignment = Alignment.Start,
     ) {
@@ -738,6 +775,8 @@ private fun MeloXUpstreamLyricLine(
             line = line,
             playbackTimeProvider = playbackTimeProvider,
             supportsTimedLyrics = supportsTimedLyrics,
+            fontScale = fontScale,
+            reduceMotion = reduceMotion,
             timingEffectsStrength = focusProgress,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -745,7 +784,7 @@ private fun MeloXUpstreamLyricLine(
         // When the user enables translation, every source line that has a
         // translation keeps it directly underneath. Keeping annotations resident
         // also prevents focus changes from reflowing the scroll geometry.
-        val romanSize = max(UpstreamLyrics.FONT_SIZE_SP * UpstreamLyrics.ROMANIZATION_FONT_SCALE, 13f)
+        val romanSize = max(UpstreamLyrics.FONT_SIZE_SP * fontScale * UpstreamLyrics.ROMANIZATION_FONT_SCALE, 13f)
         if (showRomanization) {
             Text(
                 text = line.romanization.orEmpty(),
@@ -757,7 +796,7 @@ private fun MeloXUpstreamLyricLine(
             Spacer(Modifier.height((romanSize * 1.2f).dp + UpstreamLyrics.ANNOTATION_SPACING_DP.dp))
         }
 
-        val translationSize = max(UpstreamLyrics.FONT_SIZE_SP * UpstreamLyrics.TRANSLATION_FONT_SCALE, 13f)
+        val translationSize = max(UpstreamLyrics.FONT_SIZE_SP * fontScale * UpstreamLyrics.TRANSLATION_FONT_SCALE, 13f)
         if (showTranslation) {
             Text(
                 text = line.translation.orEmpty(),
@@ -767,11 +806,11 @@ private fun MeloXUpstreamLyricLine(
                 color = Color.White.copy(alpha = UpstreamLyrics.ANNOTATION_OPACITY),
                 textAlign = TextAlign.Start,
                 fontSize = max(
-                    UpstreamLyrics.FONT_SIZE_SP * UpstreamLyrics.TRANSLATION_FONT_SCALE,
+                    UpstreamLyrics.FONT_SIZE_SP * fontScale * UpstreamLyrics.TRANSLATION_FONT_SCALE,
                     13f,
                 ).sp,
                 lineHeight = max(
-                    UpstreamLyrics.FONT_SIZE_SP * UpstreamLyrics.TRANSLATION_FONT_SCALE,
+                    UpstreamLyrics.FONT_SIZE_SP * fontScale * UpstreamLyrics.TRANSLATION_FONT_SCALE,
                     13f,
                 ).sp * 1.2f,
                 fontWeight = FontWeight.Black,
@@ -802,6 +841,8 @@ private fun MeloXGlyphLyricText(
     line: LyricLine,
     playbackTimeProvider: () -> Long,
     supportsTimedLyrics: Boolean,
+    fontScale: Float,
+    reduceMotion: Boolean,
     timingEffectsStrength: Float,
     modifier: Modifier = Modifier,
 ) {
@@ -811,8 +852,8 @@ private fun MeloXGlyphLyricText(
         val widthPx = with(density) { maxWidth.roundToPx().coerceAtLeast(1) }
         val style = TextStyle(
             color = Color.White,
-            fontSize = UpstreamLyrics.FONT_SIZE_SP.sp,
-            lineHeight = UpstreamLyrics.LINE_HEIGHT_SP.sp,
+            fontSize = (UpstreamLyrics.FONT_SIZE_SP * fontScale).sp,
+            lineHeight = (UpstreamLyrics.LINE_HEIGHT_SP * fontScale).sp,
             fontWeight = FontWeight.Black,
         )
         val layout = remember(line.text, widthPx, style) {
@@ -847,6 +888,8 @@ private fun MeloXGlyphLyricText(
                 line = line,
                 playbackTimeMs = playbackTimeMs,
                 density = density.density,
+                reduceMotion = reduceMotion,
+                fontScale = fontScale,
             )
 
             // Render each timed character by clipping the *normally shaped full
@@ -953,6 +996,8 @@ private fun sourceGlyphVisuals(
     line: LyricLine,
     playbackTimeMs: Long,
     density: Float,
+    reduceMotion: Boolean,
+    fontScale: Float,
 ): List<MeloXGlyphVisual> {
     val result = MutableList(line.text.length) {
         MeloXGlyphVisual(0f, 0f, 1f, 0f)
@@ -985,7 +1030,8 @@ private fun sourceGlyphVisuals(
             val lift = if (playbackTimeMs <= start) 0f else sourceSmootherStep(
                 ((playbackTimeMs - start) / max(liftEnd - start, 1f)).toFloat(),
             )
-            val risePx = min(max(UpstreamLyrics.FONT_SIZE_SP * .1f, 1.5f), 6f) * density
+            val risePx = if (reduceMotion) 0f else
+                min(max(UpstreamLyrics.FONT_SIZE_SP * fontScale * .1f, 1.5f), 6f) * density
             val envelope = if (longTone) sourceLongToneEnvelope(
                 playbackTimeMs.toFloat(), syllable.startTimeMs.toFloat(), syllableDuration, local, count,
             ) else 0f
@@ -995,7 +1041,8 @@ private fun sourceGlyphVisuals(
                         (2800f - UpstreamLyrics.LONG_TONE_THRESHOLD_MS),
                 )
             } else 0f
-            val scale = 1f + (UpstreamLyrics.LONG_TONE_MAX_SCALE - 1f) * envelope * expansionAmount
+            val scale = if (reduceMotion) 1f else
+                1f + (UpstreamLyrics.LONG_TONE_MAX_SCALE - 1f) * envelope * expansionAmount
             val glowAmount = if (longTone) .32f + .38f * sourceSmootherStep(
                 (syllableDuration - UpstreamLyrics.LONG_TONE_THRESHOLD_MS) /
                     (2800f - UpstreamLyrics.LONG_TONE_THRESHOLD_MS),
@@ -1004,7 +1051,7 @@ private fun sourceGlyphVisuals(
                 reveal = reveal,
                 liftPx = risePx * lift,
                 scale = scale,
-                glow = envelope * glowAmount,
+                glow = if (reduceMotion) 0f else envelope * glowAmount,
             )
         }
     }
@@ -1163,7 +1210,7 @@ private fun sourceHighlightedIndex(lines: List<LyricLine>, playbackTimeMs: Long)
     var upper = lines.size
     while (lower < upper) {
         val middle = lower + (upper - lower) / 2
-        if (lines[middle].timeMs <= playbackTimeMs) lower = middle + 1 else upper = middle
+        if (sourceLineActivationTimeMs(lines[middle]) <= playbackTimeMs) lower = middle + 1 else upper = middle
     }
     return lower - 1
 }
@@ -1171,10 +1218,10 @@ private fun sourceHighlightedIndex(lines: List<LyricLine>, playbackTimeMs: Long)
 private fun sourceFocusAnimationDurationMs(index: Int, lines: List<LyricLine>): Int {
     if (index !in lines.indices) return 300
     val available = if (index + 1 < lines.size) {
-        lines[index + 1].timeMs - lines[index].timeMs
+        sourceLineActivationTimeMs(lines[index + 1]) - sourceLineActivationTimeMs(lines[index])
     } else null
     if (available == null || available <= 0L) return 300
-    return (available * 0.35f).coerceIn(50f, 300f).roundToInt()
+    return (available * 0.30f).coerceIn(50f, 240f).roundToInt()
 }
 
 private fun sourceRemainingFocusDurationMs(
@@ -1183,8 +1230,11 @@ private fun sourceRemainingFocusDurationMs(
     lines: List<LyricLine>,
 ): Float? {
     if (index !in lines.indices || index + 1 >= lines.size) return null
-    return max((lines[index + 1].timeMs - playbackTimeMs).toFloat(), 0f)
+    return max((sourceLineActivationTimeMs(lines[index + 1]) - playbackTimeMs).toFloat(), 0f)
 }
+
+private fun sourceLineActivationTimeMs(line: LyricLine): Long =
+    line.syllables.minOfOrNull { it.startTimeMs } ?: line.timeMs
 
 private data class SourceCascadeLineTiming(val delayMs: Float, val durationMs: Float)
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -214,6 +213,17 @@ fun MeloXIOSLyricsPanel(
     val scaleProgress = remember(document) {
         List(lines.size) { Animatable(0f) }
     }
+    val cascadeLineProgress = remember(document) {
+        List(lines.size) { Animatable(1f) }
+    }
+    val cascadeScrollProgress = remember(document) { Animatable(1f) }
+    var cascadeDistancePx by remember(document) { mutableStateOf(0f) }
+    var cascadeInitialOffsets by remember(document) {
+        mutableStateOf<Map<Int, Float>>(emptyMap())
+    }
+    var cascadeDestinationOffsets by remember(document) {
+        mutableStateOf<Map<Int, Float>>(emptyMap())
+    }
     val rowHeightsPx = remember(document) { mutableStateMapOf<Int, Int>() }
     var viewportHeightPx by remember(document) { mutableIntStateOf(0) }
     var visualFocusIndex by remember(document) { mutableIntStateOf(-1) }
@@ -245,6 +255,35 @@ fun MeloXIOSLyricsPanel(
             height += annotationFontPx * 1.2f + annotationSpacingPx
         }
         return height
+    }
+
+    fun settledMovementOffset(index: Int, focusIndex: Int): Float {
+        if (focusIndex !in lines.indices || index <= focusIndex) return 0f
+        return max(
+            estimatedHeight(focusIndex) * (UpstreamLyrics.CURRENT_LINE_SCALE - 1f),
+            0f,
+        )
+    }
+
+    fun currentMovementOffset(index: Int): Float {
+        val initial = cascadeInitialOffsets[index]
+            ?: return settledMovementOffset(index, visualFocusIndex)
+        val destination = cascadeDestinationOffsets[index] ?: 0f
+        val scrollProgress = cascadeScrollProgress.value
+        val lineProgress = cascadeLineProgress[index].value
+        // The list itself moves by -distance * scrollProgress. This translation
+        // cancels that motion until the row's delayed progress starts, then lets
+        // the row catch up to its destination with the source spring.
+        return initial + cascadeDistancePx * scrollProgress -
+            (cascadeDistancePx + initial - destination) * lineProgress
+    }
+
+    suspend fun clearCascadePresentation(focusIndex: Int) {
+        visualFocusIndex = focusIndex
+        cascadeInitialOffsets = emptyMap()
+        cascadeDestinationOffsets = emptyMap()
+        cascadeDistancePx = 0f
+        cascadeScrollProgress.snapTo(1f)
     }
 
     suspend fun handOffFocusColor(nextIndex: Int) = coroutineScope {
@@ -333,6 +372,12 @@ fun MeloXIOSLyricsPanel(
         playbackFocusGeneration += 1
     }
 
+    // A real drag cancels the automatic cascade. Remove any remaining visual
+    // compensation so the rows track the user's finger one-to-one.
+    LaunchedEffect(isBrowsingLyrics, document) {
+        if (isBrowsingLyrics) clearCascadePresentation(visualFocusIndex)
+    }
+
     BoxWithConstraints(
         modifier = modifier
             .fillMaxSize()
@@ -358,6 +403,7 @@ fun MeloXIOSLyricsPanel(
             highlightedIndex,
             playbackFocusGeneration,
             viewportHeightPx,
+            isBrowsingLyrics,
             document,
         ) {
             val nextIndex = highlightedIndex
@@ -380,7 +426,7 @@ fun MeloXIOSLyricsPanel(
                 scaleProgress.forEachIndexed { index, anim ->
                     anim.snapTo(if (index == nextIndex) 1f else 0f)
                 }
-                visualFocusIndex = nextIndex
+                clearCascadePresentation(nextIndex)
                 return@LaunchedEffect
             }
 
@@ -403,45 +449,113 @@ fun MeloXIOSLyricsPanel(
                 else min(fullCascadeMs, availableMs)
             }
 
-            // The source changes its visual focus at transition start and carries
-            // the previous presentation through a cancellable transition. Keeping
-            // visualFocusIndex on the old row until scrolling finishes made blur,
-            // opacity and timed rendering all jump on the final frame.
+            val desiredTop = -targetOffset.toFloat()
+            val targetItem = listState.layoutInfo.visibleItemsInfo
+                .firstOrNull { it.index == nextIndex + 1 }
+            if (!isAdjacentForward || cascadeDurationMs <= 0f || targetItem == null) {
+                clearCascadePresentation(nextIndex)
+                coroutineScope {
+                    launch { handOffFocusColor(nextIndex) }
+                    launch { handOffFocusScale(previousIndex, nextIndex) }
+                    launch {
+                        if (cascadeDurationMs <= 0f) {
+                            listState.scrollToItem(nextIndex + 1, targetOffset)
+                        } else {
+                            listState.animateScrollToItem(nextIndex + 1, targetOffset)
+                        }
+                    }
+                }
+                return@LaunchedEffect
+            }
+
+            val movementDistance = targetItem.offset - desiredTop
+            if (abs(movementDistance) <= 0.5f) {
+                clearCascadePresentation(nextIndex)
+                handOffFocusColor(nextIndex)
+                handOffFocusScale(previousIndex, nextIndex)
+                return@LaunchedEffect
+            }
+
+            val visibleLineIndexes = listState.layoutInfo.visibleItemsInfo
+                .mapNotNull { (it.index - 1).takeIf(lines.indices::contains) }
+            val firstVisible = visibleLineIndexes.minOrNull() ?: max(nextIndex - 1, 0)
+            val lastVisible = visibleLineIndexes.maxOrNull() ?: nextIndex
+            val firstMoving = min(firstVisible, max(nextIndex - 1, 0))
+            val lastMoving = max(
+                lastVisible,
+                min(nextIndex + 8, lines.lastIndex), // six safety + two preload
+            )
+            val movingIndexes = firstMoving..lastMoving
+            val carriedOffsets = movingIndexes.associateWith(::currentMovementOffset)
+            val destinations = movingIndexes.associateWith {
+                settledMovementOffset(it, nextIndex)
+            }
+
+            // Prepare a new transition from the current presentation. Animatable's
+            // cancellation and carried values make dense lyric changes continue
+            // smoothly instead of restarting every row from zero.
+            cascadeDistancePx = movementDistance
+            cascadeInitialOffsets = carriedOffsets
+            cascadeDestinationOffsets = destinations
+            cascadeScrollProgress.snapTo(0f)
+            movingIndexes.forEach { cascadeLineProgress[it].snapTo(0f) }
             visualFocusIndex = nextIndex
+
+            val firstChasing = max(nextIndex - 1, 0)
+            val maximumChaseOrder = max(lastMoving - firstChasing, 0)
+            val lineTimings = sourceCascadeLineTimings(
+                maximumLineOrder = maximumChaseOrder,
+                animationDurationMs = cascadeDurationMs,
+            )
+            val slowestDuration = lineTimings.first().durationMs
 
             coroutineScope {
                 launch { handOffFocusColor(nextIndex) }
                 launch { handOffFocusScale(previousIndex, nextIndex) }
-                launch {
-                    if (!isAdjacentForward) {
-                        listState.animateScrollToItem(nextIndex + 1, targetOffset)
-                        return@launch
-                    }
-                    if (cascadeDurationMs <= 0f) {
-                        listState.scrollToItem(nextIndex + 1, targetOffset)
-                        return@launch
-                    }
 
-                    val desiredTop = -targetOffset.toFloat()
-                    val targetItem = listState.layoutInfo.visibleItemsInfo
-                        .firstOrNull { it.index == nextIndex + 1 }
-                    if (targetItem == null) {
-                        listState.animateScrollToItem(nextIndex + 1, targetOffset)
-                    } else {
-                        // animateScrollToItem uses Compose's generic spring. MeloX's
-                        // lyric motion has a fixed source duration, so drive the
-                        // adjacent-line distance with the same smooth timing curve.
-                        val distance = targetItem.offset - desiredTop
-                        listState.animateScrollBy(
-                            value = distance,
+                // Drive the logical LazyColumn scroll and its compensation from
+                // one frame-clock value, avoiding drift between two animations.
+                launch {
+                    var previousScrollProgress = 0f
+                    listState.scroll {
+                        cascadeScrollProgress.animateTo(
+                            targetValue = 1f,
                             animationSpec = tween(
                                 durationMillis = cascadeDurationMs.roundToInt(),
                                 easing = SourceSmoothStepEasing,
+                            ),
+                        ) {
+                            val delta = (value - previousScrollProgress) * movementDistance
+                            scrollBy(delta)
+                            previousScrollProgress = value
+                        }
+                    }
+                }
+
+                movingIndexes.forEach { index ->
+                    val movementOrder = max(index - nextIndex, 0)
+                    val chaseOrder = (index - firstChasing).coerceAtLeast(0)
+                    val movementTiming = lineTimings[min(movementOrder, lineTimings.lastIndex)]
+                    val chaseTiming = lineTimings[min(chaseOrder, lineTimings.lastIndex)]
+                    val duration = slowestDuration +
+                        (chaseTiming.durationMs - slowestDuration) *
+                        UpstreamLyrics.CASCADE_CHASE_SPEED_GRADIENT
+                    val bounce = sourceCascadeBounce(chaseOrder, maximumChaseOrder)
+                    launch {
+                        if (movementTiming.delayMs > 0f) {
+                            delay(movementTiming.delayMs.toLong())
+                        }
+                        cascadeLineProgress[index].animateTo(
+                            targetValue = 1f,
+                            animationSpec = tween(
+                                durationMillis = max(duration, 1f).roundToInt(),
+                                easing = SourceSpringEasing(bounce),
                             ),
                         )
                     }
                 }
             }
+            clearCascadePresentation(nextIndex)
         }
 
         when {
@@ -493,7 +607,7 @@ fun MeloXIOSLyricsPanel(
                         key = { index, line -> "${line.timeMs}:$index" },
                     ) { index, line ->
                         val height = estimatedHeight(index)
-                        val visualOffset = 0f
+                        val visualOffset = currentMovementOffset(index)
                         val frameMinY = visibleItemsByIndex[index + 1]?.offset?.toFloat()
                             ?: focusAnchorY + (index - visualFocusIndex) * lyricStridePx
                         val visualMidY = frameMinY + visualOffset + height * 0.5f

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -27,7 +28,6 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
@@ -144,7 +144,6 @@ fun MeloXIOSLyricsPanel(
         )
     }
     val listState = rememberLazyListState()
-    val scope = rememberCoroutineScope()
     val density = LocalDensity.current
     val mediaId = state.mediaId
 
@@ -389,20 +388,11 @@ fun MeloXIOSLyricsPanel(
                 return@LaunchedEffect
             }
 
-            scope.launch { handOffFocusColor(nextIndex) }
-            scope.launch { handOffFocusScale(previousIndex, nextIndex) }
-
             val baseDurationMs = sourceFocusAnimationDurationMs(nextIndex, lines)
             val isAdjacentForward = nextIndex == previousIndex + 1
             val effectivePosition = renderedPositionState.longValue +
                 if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS
             val remainingMs = sourceRemainingFocusDurationMs(nextIndex, effectivePosition, lines)
-
-            if (!isAdjacentForward) {
-                listState.animateScrollToItem(nextIndex + 1, targetOffset)
-                visualFocusIndex = nextIndex
-                return@LaunchedEffect
-            }
 
             val fullCascadeMs = max(baseDurationMs.toFloat(), UpstreamLyrics.CASCADE_DURATION_MS)
             val availableMs = remainingMs?.coerceAtLeast(0f)
@@ -413,15 +403,45 @@ fun MeloXIOSLyricsPanel(
                 else min(fullCascadeMs, availableMs)
             }
 
-            if (cascadeDurationMs <= 0f) {
-                listState.scrollToItem(nextIndex + 1, targetOffset)
-            } else {
-                // LazyColumn limits composition/layout to visible rows. Its scroll
-                // animation is frame-clock driven, avoiding the all-row cascade of
-                // Animatables that previously contended with glyph rendering.
-                listState.animateScrollToItem(nextIndex + 1, targetOffset)
-            }
+            // The source changes its visual focus at transition start and carries
+            // the previous presentation through a cancellable transition. Keeping
+            // visualFocusIndex on the old row until scrolling finishes made blur,
+            // opacity and timed rendering all jump on the final frame.
             visualFocusIndex = nextIndex
+
+            coroutineScope {
+                launch { handOffFocusColor(nextIndex) }
+                launch { handOffFocusScale(previousIndex, nextIndex) }
+                launch {
+                    if (!isAdjacentForward) {
+                        listState.animateScrollToItem(nextIndex + 1, targetOffset)
+                        return@launch
+                    }
+                    if (cascadeDurationMs <= 0f) {
+                        listState.scrollToItem(nextIndex + 1, targetOffset)
+                        return@launch
+                    }
+
+                    val desiredTop = -targetOffset.toFloat()
+                    val targetItem = listState.layoutInfo.visibleItemsInfo
+                        .firstOrNull { it.index == nextIndex + 1 }
+                    if (targetItem == null) {
+                        listState.animateScrollToItem(nextIndex + 1, targetOffset)
+                    } else {
+                        // animateScrollToItem uses Compose's generic spring. MeloX's
+                        // lyric motion has a fixed source duration, so drive the
+                        // adjacent-line distance with the same smooth timing curve.
+                        val distance = targetItem.offset - desiredTop
+                        listState.animateScrollBy(
+                            value = distance,
+                            animationSpec = tween(
+                                durationMillis = cascadeDurationMs.roundToInt(),
+                                easing = SourceSmoothStepEasing,
+                            ),
+                        )
+                    }
+                }
+            }
         }
 
         when {
@@ -477,7 +497,16 @@ fun MeloXIOSLyricsPanel(
                         val frameMinY = visibleItemsByIndex[index + 1]?.offset?.toFloat()
                             ?: focusAnchorY + (index - visualFocusIndex) * lyricStridePx
                         val visualMidY = frameMinY + visualOffset + height * 0.5f
-                        val distance = abs(visualMidY - focusAnchorY)
+                        // Automatic movement should not feed its own changing row
+                        // geometry back into blur/opacity. The upstream transition
+                        // freezes presentation geometry while the cascade runs.
+                        // Index distance is its stable LazyColumn equivalent; while
+                        // browsing, actual viewport distance remains interactive.
+                        val distance = if (isBrowsingLyrics || visualFocusIndex !in lines.indices) {
+                            abs(visualMidY - focusAnchorY)
+                        } else {
+                            abs(index - visualFocusIndex) * lyricStridePx
+                        }
                         val fp = focusProgress[index].value.coerceIn(0f, 1f)
                         val effectiveFocus = fp
                         val distanceBlur = sourceDistanceBlurRadius(
@@ -513,7 +542,7 @@ fun MeloXIOSLyricsPanel(
                         MeloXUpstreamLyricLine(
                             line = line,
                             playbackTimeProvider = playbackTimeProvider,
-                            timed = hasSyllableSync && index == highlightedIndex,
+                            supportsTimedLyrics = line.syllables.isNotEmpty(),
                             focusProgress = effectiveFocus,
                             visualScale = scale,
                             visualOffsetPx = visualOffset,
@@ -551,7 +580,7 @@ fun MeloXIOSLyricsPanel(
 private fun MeloXUpstreamLyricLine(
     line: LyricLine,
     playbackTimeProvider: () -> Long,
-    timed: Boolean,
+    supportsTimedLyrics: Boolean,
     focusProgress: Float,
     visualScale: Float,
     visualOffsetPx: Float,
@@ -594,7 +623,8 @@ private fun MeloXUpstreamLyricLine(
         MeloXGlyphLyricText(
             line = line,
             playbackTimeProvider = playbackTimeProvider,
-            timed = timed && line.syllables.isNotEmpty(),
+            supportsTimedLyrics = supportsTimedLyrics,
+            timingEffectsStrength = focusProgress,
             modifier = Modifier.fillMaxWidth(),
         )
 
@@ -657,7 +687,8 @@ private data class MeloXGlyphVisual(
 private fun MeloXGlyphLyricText(
     line: LyricLine,
     playbackTimeProvider: () -> Long,
-    timed: Boolean,
+    supportsTimedLyrics: Boolean,
+    timingEffectsStrength: Float,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
@@ -681,9 +712,17 @@ private fun MeloXGlyphLyricText(
         val height = with(density) { layout.size.height.toDp() }
 
         Canvas(Modifier.fillMaxWidth().height(height)) {
-            if (!timed || line.text.isEmpty()) {
+            val playbackTimeMs = playbackTimeProvider()
+            val effectsStrength = sourceTimingEffectsStrength(
+                line = line,
+                playbackTimeMs = playbackTimeMs,
+                focusProgress = timingEffectsStrength,
+            )
+            if (!supportsTimedLyrics || effectsStrength <= 0.0001f || line.text.isEmpty()) {
                 // drawText keeps Compose/Android's normal shaping and font fallback,
-                // including Japanese/CJK/emoji fallback fonts.
+                // including Japanese/CJK/emoji fallback fonts. This is also the
+                // zero-strength state of MeloX's timed renderer, not a second
+                // competing text path with different opacity.
                 drawText(layout, color = Color.White)
                 return@Canvas
             }
@@ -692,7 +731,7 @@ private fun MeloXGlyphLyricText(
             // Canvas only. It avoids recomposing or relaying out the lyric row.
             val visuals = sourceGlyphVisuals(
                 line = line,
-                playbackTimeMs = playbackTimeProvider(),
+                playbackTimeMs = playbackTimeMs,
                 density = density.density,
             )
 
@@ -707,8 +746,13 @@ private fun MeloXGlyphLyricText(
                 val fx = visuals.getOrElse(offset) { MeloXGlyphVisual(0f, 0f, 1f, 0f) }
 
                 withTransform({
-                    translate(left = 0f, top = -fx.liftPx)
-                    scale(scaleX = fx.scale, scaleY = fx.scale, pivot = bounds.center)
+                    translate(left = 0f, top = -fx.liftPx * effectsStrength)
+                    val presentationScale = 1f + (fx.scale - 1f) * effectsStrength
+                    scale(
+                        scaleX = presentationScale,
+                        scaleY = presentationScale,
+                        pivot = bounds.center,
+                    )
                 }) {
                     clipRect(
                         left = bounds.left,
@@ -719,7 +763,10 @@ private fun MeloXGlyphLyricText(
                         // Upstream draws a complete unplayed layer first.
                         drawText(
                             layout,
-                            color = Color.White.copy(alpha = UpstreamLyrics.UNPLAYED_OPACITY),
+                            color = Color.White.copy(
+                                alpha = 1f -
+                                    (1f - UpstreamLyrics.UNPLAYED_OPACITY) * effectsStrength,
+                            ),
                         )
 
                         val reveal = fx.reveal.coerceIn(0f, 1f)
@@ -775,9 +822,10 @@ private fun MeloXGlyphLyricText(
                         // Keep the upstream long-tone envelope without relying on
                         // vector glyph extraction. Two low-opacity passes provide
                         // the bloom while the final pass is the actual played text.
-                        if (fx.glow > 0.001f) {
-                            drawRevealed((fx.glow * .10f).coerceIn(0f, .24f))
-                            drawRevealed((fx.glow * .18f).coerceIn(0f, .36f))
+                        val glow = fx.glow * effectsStrength
+                        if (glow > 0.001f) {
+                            drawRevealed((glow * .10f).coerceIn(0f, .24f))
+                            drawRevealed((glow * .18f).coerceIn(0f, .36f))
                         }
                         drawRevealed(1f)
                     }
@@ -847,6 +895,28 @@ private fun sourceGlyphVisuals(
         }
     }
     return result
+}
+
+/**
+ * MeloX feeds focus-colour presentation progress into LyricGlowTextRenderer so
+ * its unplayed opacity, lift, scale and glow enter as one transition. Some YRC
+ * files place the line timestamp slightly before the first syllable timestamp;
+ * delaying presentation strength until that syllable begins prevents a fully
+ * unplayed line from dimming during this metadata gap.
+ */
+private fun sourceTimingEffectsStrength(
+    line: LyricLine,
+    playbackTimeMs: Long,
+    focusProgress: Float,
+): Float {
+    val focus = focusProgress.coerceIn(0f, 1f)
+    if (focus <= 0f || line.syllables.isEmpty()) return 0f
+    val firstSyllableStartMs = line.syllables.minOf { it.startTimeMs }
+    val activation = sourceSmootherStep(
+        (playbackTimeMs - firstSyllableStartMs).toFloat() /
+            UpstreamLyrics.FOCUS_COLOR_DURATION_MS.toFloat(),
+    )
+    return min(focus, activation)
 }
 
 private fun sourceTimedAnnotatedString(line: LyricLine, playbackTimeMs: Long) =

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
@@ -14,8 +14,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
@@ -141,7 +143,7 @@ fun MeloXIOSLyricsPanel(
             cookieProvider = { NeteaseSessionStore.readCookie(context) },
         )
     }
-    val scrollState = rememberScrollState()
+    val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val density = LocalDensity.current
     val mediaId = state.mediaId
@@ -152,25 +154,12 @@ fun MeloXIOSLyricsPanel(
 
     var anchorPositionMs by remember(mediaId) { mutableLongStateOf(state.positionMs) }
     var anchorRealtimeMs by remember(mediaId) { mutableLongStateOf(SystemClock.elapsedRealtime()) }
-    var renderedPositionMs by remember(mediaId) { mutableLongStateOf(state.positionMs) }
+    val renderedPositionState = remember(mediaId) { mutableLongStateOf(state.positionMs) }
 
     LaunchedEffect(state.positionMs, state.isPlaying, mediaId) {
         anchorPositionMs = state.positionMs
         anchorRealtimeMs = SystemClock.elapsedRealtime()
-        renderedPositionMs = state.positionMs
-    }
-
-    // SwiftUI TimelineView(.animation) tracks the display clock. 16 ms keeps the
-    // Android presentation on the same 60 Hz minimum cadence used by upstream.
-    LaunchedEffect(state.isPlaying, mediaId) {
-        while (true) {
-            renderedPositionMs = if (state.isPlaying) {
-                anchorPositionMs + (SystemClock.elapsedRealtime() - anchorRealtimeMs)
-            } else {
-                anchorPositionMs
-            }
-            delay(if (state.isPlaying) 16L else 200L)
-        }
+        renderedPositionState.longValue = state.positionMs
     }
 
     LaunchedEffect(mediaId) {
@@ -189,14 +178,37 @@ fun MeloXIOSLyricsPanel(
     val document = lyrics
     val lines = document?.lines.orEmpty()
     val hasSyllableSync = remember(document) { lines.any { it.syllables.isNotEmpty() } }
-    val effectivePositionMs = renderedPositionMs + if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS
-    val highlightedIndex = remember(lines, effectivePositionMs) {
-        sourceHighlightedIndex(lines, effectivePositionMs)
+    var highlightedIndex by remember(document) {
+        mutableIntStateOf(
+            sourceHighlightedIndex(
+                lines,
+                state.positionMs + if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS,
+            ),
+        )
+    }
+    val playbackTimeProvider = remember(mediaId) {
+        { renderedPositionState.longValue }
     }
 
-    val movementOffsets = remember(document) {
-        List(lines.size) { Animatable(0f) }
+    // Update the line index only when it actually changes. The per-frame time is
+    // read later from Canvas, so the 60 Hz clock invalidates drawing rather than
+    // recomposing and relaying out the complete lyric list.
+    LaunchedEffect(state.isPlaying, mediaId, document, hasSyllableSync) {
+        while (true) {
+            val position = if (state.isPlaying) {
+                anchorPositionMs + (SystemClock.elapsedRealtime() - anchorRealtimeMs)
+            } else {
+                anchorPositionMs
+            }
+            renderedPositionState.longValue = position
+            val effectivePosition = position +
+                if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS
+            val nextIndex = sourceHighlightedIndex(lines, effectivePosition)
+            if (nextIndex != highlightedIndex) highlightedIndex = nextIndex
+            if (state.isPlaying) withFrameNanos { } else delay(200L)
+        }
     }
+
     val focusProgress = remember(document) {
         List(lines.size) { Animatable(0f) }
     }
@@ -204,11 +216,9 @@ fun MeloXIOSLyricsPanel(
         List(lines.size) { Animatable(0f) }
     }
     val rowHeightsPx = remember(document) { mutableStateMapOf<Int, Int>() }
-    var layoutRevision by remember(document) { mutableIntStateOf(0) }
     var viewportHeightPx by remember(document) { mutableIntStateOf(0) }
     var visualFocusIndex by remember(document) { mutableIntStateOf(-1) }
     var isBrowsingLyrics by remember(document) { mutableStateOf(false) }
-    var automaticScroll by remember(document) { mutableStateOf(false) }
     var playbackFocusGeneration by remember(document) { mutableIntStateOf(0) }
     var browseGeneration by remember(document) { mutableIntStateOf(0) }
     var scrollHideDistancePx by remember(document) { mutableStateOf(0f) }
@@ -236,19 +246,6 @@ fun MeloXIOSLyricsPanel(
             height += annotationFontPx * 1.2f + annotationSpacingPx
         }
         return height
-    }
-
-    fun rowContentTop(index: Int, topPaddingPx: Float): Float {
-        var result = topPaddingPx
-        for (i in 0 until index) {
-            result += estimatedHeight(i) + lineSpacingPx
-        }
-        return result
-    }
-
-    fun focusedFollowingOffset(index: Int, focusIndex: Int): Float {
-        if (focusIndex !in lines.indices || index <= focusIndex) return 0f
-        return max(estimatedHeight(focusIndex) * (UpstreamLyrics.CURRENT_LINE_SCALE - 1f), 0f)
     }
 
     suspend fun handOffFocusColor(nextIndex: Int) = coroutineScope {
@@ -348,14 +345,14 @@ fun MeloXIOSLyricsPanel(
             with(density) { 40.dp.toPx() },
         )
 
-        fun targetScrollFor(index: Int): Int {
-            if (index !in lines.indices || viewportHeightPx <= 0) return scrollState.value
-            val rowTop = rowContentTop(index, topPaddingPx)
-            val rowHeight = estimatedHeight(index)
+        fun focusItemScrollOffset(index: Int): Int {
+            if (index !in lines.indices || viewportHeightPx <= 0) return 0
             val viewportAnchor = viewportHeightPx * UpstreamLyrics.FOCUS_POSITION
-            return (rowTop + rowHeight * UpstreamLyrics.FOCUS_POSITION - viewportAnchor)
-                .roundToInt()
-                .coerceIn(0, scrollState.maxValue.coerceAtLeast(0))
+            val desiredItemTop = viewportAnchor -
+                estimatedHeight(index) * UpstreamLyrics.FOCUS_POSITION
+            // LazyListState uses a positive value to scroll the item farther past
+            // the viewport start. A negative value places its top below the start.
+            return -desiredItemTop.roundToInt()
         }
 
         LaunchedEffect(
@@ -374,14 +371,10 @@ fun MeloXIOSLyricsPanel(
             }
 
             val previousIndex = visualFocusIndex
-            val targetScroll = targetScrollFor(nextIndex)
+            val targetOffset = focusItemScrollOffset(nextIndex)
 
             if (previousIndex !in lines.indices) {
-                automaticScroll = true
-                scrollState.scrollTo(targetScroll)
-                movementOffsets.forEachIndexed { index, anim ->
-                    anim.snapTo(focusedFollowingOffset(index, nextIndex))
-                }
+                listState.scrollToItem(nextIndex + 1, targetOffset)
                 focusProgress.forEachIndexed { index, anim ->
                     anim.snapTo(if (index == nextIndex) 1f else 0f)
                 }
@@ -389,20 +382,10 @@ fun MeloXIOSLyricsPanel(
                     anim.snapTo(if (index == nextIndex) 1f else 0f)
                 }
                 visualFocusIndex = nextIndex
-                automaticScroll = false
                 return@LaunchedEffect
             }
 
             if (previousIndex == nextIndex) {
-                // Geometry may have changed after annotations were measured.
-                if (abs(scrollState.value - targetScroll) > 2) {
-                    automaticScroll = true
-                    scrollState.animateScrollTo(
-                        targetScroll,
-                        tween(120, easing = SourceSmoothStepEasing),
-                    )
-                    automaticScroll = false
-                }
                 return@LaunchedEffect
             }
 
@@ -411,28 +394,13 @@ fun MeloXIOSLyricsPanel(
 
             val baseDurationMs = sourceFocusAnimationDurationMs(nextIndex, lines)
             val isAdjacentForward = nextIndex == previousIndex + 1
-            val remainingMs = sourceRemainingFocusDurationMs(nextIndex, effectivePositionMs, lines)
-            val oldScroll = scrollState.value
-            val movementDistance = (targetScroll - oldScroll).toFloat()
+            val effectivePosition = renderedPositionState.longValue +
+                if (hasSyllableSync) 0L else UpstreamLyrics.NON_YRC_ADVANCE_MS
+            val remainingMs = sourceRemainingFocusDurationMs(nextIndex, effectivePosition, lines)
 
             if (!isAdjacentForward) {
-                automaticScroll = true
-                scrollState.animateScrollTo(
-                    targetScroll,
-                    tween(baseDurationMs, easing = SourceSmoothStepEasing),
-                )
-                coroutineScope {
-                    movementOffsets.forEachIndexed { index, anim ->
-                        launch {
-                            anim.animateTo(
-                                focusedFollowingOffset(index, nextIndex),
-                                tween(baseDurationMs, easing = SourceSmoothStepEasing),
-                            )
-                        }
-                    }
-                }
+                listState.animateScrollToItem(nextIndex + 1, targetOffset)
                 visualFocusIndex = nextIndex
-                automaticScroll = false
                 return@LaunchedEffect
             }
 
@@ -445,67 +413,15 @@ fun MeloXIOSLyricsPanel(
                 else min(fullCascadeMs, availableMs)
             }
 
-            automaticScroll = true
-            // Same preparation used by AppleMusicLyricsView: put the scroll view at
-            // its destination without animation and carry every row by the inverse
-            // movement distance, then release rows through the cascade.
-            val carried = movementOffsets.map { it.value }
-            scrollState.animateScrollTo(
-                targetScroll,
-                tween(
-                    durationMillis = max(cascadeDurationMs, 1f).roundToInt(),
-                    easing = SourceSmoothStepEasing,
-                ),
-            )
-            movementOffsets.forEachIndexed { index, anim ->
-                anim.snapTo(carried[index])
+            if (cascadeDurationMs <= 0f) {
+                listState.scrollToItem(nextIndex + 1, targetOffset)
+            } else {
+                // LazyColumn limits composition/layout to visible rows. Its scroll
+                // animation is frame-clock driven, avoiding the all-row cascade of
+                // Animatables that previously contended with glyph rendering.
+                listState.animateScrollToItem(nextIndex + 1, targetOffset)
             }
             visualFocusIndex = nextIndex
-
-            if (cascadeDurationMs <= 0f || abs(movementDistance) <= 0.5f) {
-                movementOffsets.forEachIndexed { index, anim ->
-                    anim.snapTo(focusedFollowingOffset(index, nextIndex))
-                }
-                automaticScroll = false
-                return@LaunchedEffect
-            }
-
-            val firstMoving = max(nextIndex - 1, 0)
-            val lastMoving = min(nextIndex + 8, lines.lastIndex) // 6 safety + 2 preload
-            val maxChaseOrder = max(lastMoving - firstMoving, 0)
-            val lineTimings = sourceCascadeLineTimings(
-                maximumLineOrder = max(lastMoving - nextIndex, 0),
-                animationDurationMs = cascadeDurationMs,
-            )
-            val slowestDuration = lineTimings.firstOrNull()?.durationMs ?: cascadeDurationMs
-
-            coroutineScope {
-                movementOffsets.forEachIndexed { index, anim ->
-                    val destination = focusedFollowingOffset(index, nextIndex)
-                    if (index !in firstMoving..lastMoving) {
-                        launch { anim.snapTo(destination) }
-                        return@forEachIndexed
-                    }
-                    val movementOrder = max(index - nextIndex, 0)
-                    val chaseOrder = max(index - firstMoving, 0)
-                    val movementTiming = lineTimings[min(movementOrder, lineTimings.lastIndex)]
-                    val chaseTiming = lineTimings[min(chaseOrder, lineTimings.lastIndex)]
-                    val duration = slowestDuration +
-                        (chaseTiming.durationMs - slowestDuration) * UpstreamLyrics.CASCADE_CHASE_SPEED_GRADIENT
-                    val bounce = sourceCascadeBounce(chaseOrder, maxChaseOrder)
-                    launch {
-                        delay(movementTiming.delayMs.toLong())
-                        anim.animateTo(
-                            destination,
-                            tween(
-                                durationMillis = max(duration, 1f).roundToInt(),
-                                easing = SourceSpringEasing(bounce),
-                            ),
-                        )
-                    }
-                }
-            }
-            automaticScroll = false
         }
 
         when {
@@ -537,23 +453,29 @@ fun MeloXIOSLyricsPanel(
             }
 
             else -> {
-                val scrollValue = scrollState.value.toFloat()
                 val focusAnchorY = viewportHeightPx * UpstreamLyrics.FOCUS_POSITION
                 val annotationHeightPx =
                     annotationFontPx * 1.2f * 2f + annotationSpacingPx * 2f
                 val lyricStridePx = max(primaryHeightPx + annotationHeightPx + lineSpacingPx, 1f)
+                val visibleItemsByIndex = listState.layoutInfo.visibleItemsInfo.associateBy { it.index }
 
-                Column(
+                LazyColumn(
+                    state = listState,
                     modifier = Modifier
                         .fillMaxSize()
-                        .nestedScroll(lyricInteractionConnection)
-                        .verticalScroll(scrollState),
+                        .nestedScroll(lyricInteractionConnection),
                 ) {
-                    Spacer(Modifier.height(with(density) { topPaddingPx.toDp() }))
-                    lines.forEachIndexed { index, line ->
+                    item(key = "lyrics-top-padding") {
+                        Spacer(Modifier.height(with(density) { topPaddingPx.toDp() }))
+                    }
+                    itemsIndexed(
+                        items = lines,
+                        key = { index, line -> "${line.timeMs}:$index" },
+                    ) { index, line ->
                         val height = estimatedHeight(index)
                         val visualOffset = 0f
-                        val frameMinY = rowContentTop(index, topPaddingPx) - scrollValue
+                        val frameMinY = visibleItemsByIndex[index + 1]?.offset?.toFloat()
+                            ?: focusAnchorY + (index - visualFocusIndex) * lyricStridePx
                         val visualMidY = frameMinY + visualOffset + height * 0.5f
                         val distance = abs(visualMidY - focusAnchorY)
                         val fp = focusProgress[index].value.coerceIn(0f, 1f)
@@ -590,7 +512,7 @@ fun MeloXIOSLyricsPanel(
 
                         MeloXUpstreamLyricLine(
                             line = line,
-                            positionMs = renderedPositionMs,
+                            playbackTimeProvider = playbackTimeProvider,
                             timed = hasSyllableSync && index == highlightedIndex,
                             focusProgress = effectiveFocus,
                             visualScale = scale,
@@ -607,7 +529,6 @@ fun MeloXIOSLyricsPanel(
                             onMeasured = { measured ->
                                 if (measured > 0 && rowHeightsPx[index] != measured) {
                                     rowHeightsPx[index] = measured
-                                    layoutRevision += 1
                                 }
                             },
                             onClick = { onInterfaceInteraction(); state.seekTo(line.timeMs) },
@@ -617,7 +538,9 @@ fun MeloXIOSLyricsPanel(
                             Spacer(Modifier.height(UpstreamLyrics.LINE_SPACING_DP.dp))
                         }
                     }
-                    Spacer(Modifier.height(with(density) { bottomPaddingPx.toDp() }))
+                    item(key = "lyrics-bottom-padding") {
+                        Spacer(Modifier.height(with(density) { bottomPaddingPx.toDp() }))
+                    }
                 }
             }
         }
@@ -627,7 +550,7 @@ fun MeloXIOSLyricsPanel(
 @Composable
 private fun MeloXUpstreamLyricLine(
     line: LyricLine,
-    positionMs: Long,
+    playbackTimeProvider: () -> Long,
     timed: Boolean,
     focusProgress: Float,
     visualScale: Float,
@@ -670,7 +593,7 @@ private fun MeloXUpstreamLyricLine(
     ) {
         MeloXGlyphLyricText(
             line = line,
-            playbackTimeMs = positionMs,
+            playbackTimeProvider = playbackTimeProvider,
             timed = timed && line.syllables.isNotEmpty(),
             modifier = Modifier.fillMaxWidth(),
         )
@@ -733,7 +656,7 @@ private data class MeloXGlyphVisual(
 @Composable
 private fun MeloXGlyphLyricText(
     line: LyricLine,
-    playbackTimeMs: Long,
+    playbackTimeProvider: () -> Long,
     timed: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -756,10 +679,6 @@ private fun MeloXGlyphLyricText(
             )
         }
         val height = with(density) { layout.size.height.toDp() }
-        val visuals = remember(line, playbackTimeMs, timed, density.density) {
-            if (timed) sourceGlyphVisuals(line, playbackTimeMs, density.density)
-            else List(line.text.length) { MeloXGlyphVisual(1f, 0f, 1f, 0f) }
-        }
 
         Canvas(Modifier.fillMaxWidth().height(height)) {
             if (!timed || line.text.isEmpty()) {
@@ -768,6 +687,14 @@ private fun MeloXGlyphLyricText(
                 drawText(layout, color = Color.White)
                 return@Canvas
             }
+
+            // Reading the frame clock state inside the draw phase invalidates this
+            // Canvas only. It avoids recomposing or relaying out the lyric row.
+            val visuals = sourceGlyphVisuals(
+                line = line,
+                playbackTimeMs = playbackTimeProvider(),
+                density = density.density,
+            )
 
             // Render each timed character by clipping the *normally shaped full
             // TextLayoutResult*. This preserves fallback glyphs. getPathForRange()

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSLyricsPanel.kt
@@ -1,14 +1,19 @@
 package com.lladlam.melox.ui.player
 
+import android.content.Context
+import android.content.Intent
 import android.os.SystemClock
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -48,6 +53,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
@@ -57,16 +63,19 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lladlam.melox.core.account.NeteaseSessionStore
 import com.lladlam.melox.core.lyrics.LyricLine
+import com.lladlam.melox.core.lyrics.LyricRomanizationAligner
 import com.lladlam.melox.core.lyrics.LyricsDocument
 import com.lladlam.melox.core.lyrics.withPseudoTiming
 import com.lladlam.melox.core.download.MeloXDownloadStore
 import com.lladlam.melox.core.network.NeteaseSearchClient
 import com.lladlam.melox.ui.settings.MeloXSettingsRuntime
+import com.lladlam.melox.ui.settings.MeloXLyricAnnotationDisplayMode
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -137,10 +146,12 @@ fun MeloXIOSLyricsPanel(
     onInterfaceInteraction: () -> Unit = {},
     onInterfaceVisibilityChange: (Boolean) -> Unit = {},
 ) {
-    val context = LocalContext.current.applicationContext
+    val context = LocalContext.current
+    val appContext = context.applicationContext
+    val haptics = LocalHapticFeedback.current
     val client = remember(context) {
         NeteaseSearchClient(
-            cookieProvider = { NeteaseSessionStore.readCookie(context) },
+            cookieProvider = { NeteaseSessionStore.readCookie(appContext) },
         )
     }
     val listState = rememberLazyListState()
@@ -165,7 +176,7 @@ fun MeloXIOSLyricsPanel(
         val songId = mediaId?.toLongOrNull() ?: return@LaunchedEffect
         isLoading = true
         errorMessage = null
-        val downloaded = MeloXDownloadStore.get(context).localLyrics(songId)
+        val downloaded = MeloXDownloadStore.get(appContext).localLyrics(songId)
         if (downloaded != null) {
             lyrics = downloaded
         } else runCatching { client.lyrics(songId) }
@@ -182,33 +193,48 @@ fun MeloXIOSLyricsPanel(
     val lines = renderedDocument?.lines.orEmpty()
     val hasSyllableSync = remember(renderedDocument) { lines.any { it.syllables.isNotEmpty() } }
     val lyricAdvanceMs = MeloXSettingsRuntime.lyricAdvanceMs.toLong()
+    val usesWordByWordPresentation = hasSyllableSync && MeloXSettingsRuntime.lyricWordByWordEnabled
+    val timedAdvanceMs = if (MeloXSettingsRuntime.lyricAdvanceAppliesToWordByWord) lyricAdvanceMs else 0L
+    val lineAdvanceMs = if (usesWordByWordPresentation) timedAdvanceMs else lyricAdvanceMs
     var highlightedIndex by remember(document) {
         mutableIntStateOf(
             sourceHighlightedIndex(
                 lines,
-                state.positionMs + lyricAdvanceMs,
+                state.positionMs + lineAdvanceMs,
             ),
         )
     }
-    val playbackTimeProvider = remember(mediaId, lyricAdvanceMs) {
-        { renderedPositionState.longValue + lyricAdvanceMs }
+    val playbackTimeProvider = remember(mediaId, timedAdvanceMs) {
+        { renderedPositionState.longValue + timedAdvanceMs }
     }
 
     // Update the line index only when it actually changes. The per-frame time is
     // read later from Canvas, so the 60 Hz clock invalidates drawing rather than
     // recomposing and relaying out the complete lyric list.
-    LaunchedEffect(state.isPlaying, mediaId, document, hasSyllableSync) {
+    val refreshRate = MeloXSettingsRuntime.lyricRefreshRate
+    val interludes = remember(lines) { sourceLyricInterludes(lines) }
+    var activeInterludeIndex by remember(document) { mutableIntStateOf(-1) }
+    LaunchedEffect(state.isPlaying, mediaId, document, hasSyllableSync, lineAdvanceMs, refreshRate) {
+        var lastFrameNanos = 0L
+        val minimumFrameNanos = 1_000_000_000L / refreshRate.coerceIn(30, 120)
         while (true) {
+            if (state.isPlaying) {
+                val frameNanos = withFrameNanos { it }
+                if (lastFrameNanos != 0L && frameNanos - lastFrameNanos < minimumFrameNanos) continue
+                lastFrameNanos = frameNanos
+            }
             val position = if (state.isPlaying) {
                 anchorPositionMs + (SystemClock.elapsedRealtime() - anchorRealtimeMs)
             } else {
                 anchorPositionMs
             }
             renderedPositionState.longValue = position
-            val effectivePosition = position + lyricAdvanceMs
+            val effectivePosition = position + lineAdvanceMs
             val nextIndex = sourceHighlightedIndex(lines, effectivePosition)
             if (nextIndex != highlightedIndex) highlightedIndex = nextIndex
-            if (state.isPlaying) withFrameNanos { } else delay(200L)
+            val nextInterlude = interludes.indexOfFirst { position >= it.startTimeMs && position < it.followingLyricTimeMs }
+            if (nextInterlude != activeInterludeIndex) activeInterludeIndex = nextInterlude
+            if (!state.isPlaying) delay(200L)
         }
     }
 
@@ -700,9 +726,13 @@ fun MeloXIOSLyricsPanel(
                             distanceBlurDp = distanceBlur,
                             focusBlurDp = focusBlur,
                             showTranslation = MeloXSettingsRuntime.showLyricTranslation &&
-                                !line.translation.isNullOrBlank(),
+                                !line.translation.isNullOrBlank() &&
+                                (MeloXSettingsRuntime.lyricTranslationDisplayMode == MeloXLyricAnnotationDisplayMode.AllLines ||
+                                    index == visualFocusIndex),
                             showRomanization = MeloXSettingsRuntime.showLyricRomanization &&
-                                !line.romanization.isNullOrBlank(),
+                                !line.romanization.isNullOrBlank() &&
+                                (MeloXSettingsRuntime.lyricRomanizationDisplayMode == MeloXLyricAnnotationDisplayMode.AllLines ||
+                                    index == visualFocusIndex),
                             reserveTranslation = MeloXSettingsRuntime.showLyricTranslation && !line.translation.isNullOrBlank(),
                             reserveRomanization = MeloXSettingsRuntime.showLyricRomanization && !line.romanization.isNullOrBlank(),
                             onMeasured = { measured ->
@@ -712,6 +742,12 @@ fun MeloXIOSLyricsPanel(
                             },
                             tapSeekEnabled = MeloXSettingsRuntime.lyricTapSeekEnabled,
                             onClick = { onInterfaceInteraction(); state.seekTo(line.timeMs) },
+                            longPressShareEnabled = MeloXSettingsRuntime.lyricLongPressShareEnabled,
+                            onLongClick = {
+                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                onInterfaceInteraction()
+                                shareLyric(context, state, line)
+                            },
                         )
 
                         if (index != lines.lastIndex) {
@@ -721,6 +757,20 @@ fun MeloXIOSLyricsPanel(
                     item(key = "lyrics-bottom-padding") {
                         Spacer(Modifier.height(with(density) { bottomPaddingPx.toDp() }))
                     }
+                }
+
+                if (MeloXSettingsRuntime.lyricInterludeCountdownEnabled && activeInterludeIndex in interludes.indices) {
+                    MeloXLyricInterludeCountdown(
+                        interlude = interludes[activeInterludeIndex],
+                        playbackTimeProvider = { renderedPositionState.longValue },
+                        reduceMotion = MeloXSettingsRuntime.lyricReduceMotion,
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(
+                                start = 8.dp,
+                                top = with(density) { (topPaddingPx - 24.dp.toPx()).coerceAtLeast(0f).toDp() },
+                            ),
+                    )
                 }
             }
         }
@@ -745,8 +795,10 @@ private fun MeloXUpstreamLyricLine(
     reserveTranslation: Boolean,
     reserveRomanization: Boolean,
     tapSeekEnabled: Boolean,
+    longPressShareEnabled: Boolean,
     onMeasured: (Int) -> Unit,
     onClick: () -> Unit,
+    onLongClick: () -> Unit,
 ) {
     // One blur layer is materially cheaper than stacking distance and focus
     // blurs on every visible row, and removes a common source of scroll jank.
@@ -767,32 +819,39 @@ private fun MeloXUpstreamLyricLine(
                 transformOrigin = TransformOrigin(0f, 0f)
             }
             .then(blurModifier)
-            .clickable(enabled = tapSeekEnabled, onClick = onClick)
+            .combinedClickable(
+                enabled = tapSeekEnabled || longPressShareEnabled,
+                onClick = { if (tapSeekEnabled) onClick() },
+                onLongClick = { if (longPressShareEnabled) onLongClick() },
+            )
             .padding(horizontal = 8.dp),
         horizontalAlignment = Alignment.Start,
     ) {
-        MeloXGlyphLyricText(
-            line = line,
-            playbackTimeProvider = playbackTimeProvider,
-            supportsTimedLyrics = supportsTimedLyrics,
-            fontScale = fontScale,
-            reduceMotion = reduceMotion,
-            timingEffectsStrength = focusProgress,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (showRomanization) {
+            MeloXRubyLyricText(
+                line = line,
+                playbackTimeProvider = playbackTimeProvider,
+                supportsTimedLyrics = supportsTimedLyrics,
+                fontScale = fontScale,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        } else {
+            MeloXGlyphLyricText(
+                line = line,
+                playbackTimeProvider = playbackTimeProvider,
+                supportsTimedLyrics = supportsTimedLyrics,
+                fontScale = fontScale,
+                reduceMotion = reduceMotion,
+                timingEffectsStrength = focusProgress,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
         // When the user enables translation, every source line that has a
         // translation keeps it directly underneath. Keeping annotations resident
         // also prevents focus changes from reflowing the scroll geometry.
         val romanSize = max(UpstreamLyrics.FONT_SIZE_SP * fontScale * UpstreamLyrics.ROMANIZATION_FONT_SCALE, 13f)
-        if (showRomanization) {
-            Text(
-                text = line.romanization.orEmpty(),
-                modifier = Modifier.fillMaxWidth().padding(top = UpstreamLyrics.ANNOTATION_SPACING_DP.dp),
-                color = Color.White.copy(alpha = UpstreamLyrics.ANNOTATION_OPACITY),
-                textAlign = TextAlign.Start, fontSize = romanSize.sp, lineHeight = (romanSize * 1.2f).sp, fontWeight = FontWeight.Black,
-            )
-        } else if (reserveRomanization) {
+        if (!showRomanization && reserveRomanization) {
             Spacer(Modifier.height((romanSize * 1.2f).dp + UpstreamLyrics.ANNOTATION_SPACING_DP.dp))
         }
 
@@ -821,12 +880,152 @@ private fun MeloXUpstreamLyricLine(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MeloXRubyLyricText(
+    line: LyricLine,
+    playbackTimeProvider: () -> Long,
+    supportsTimedLyrics: Boolean,
+    fontScale: Float,
+    modifier: Modifier = Modifier,
+) {
+    val units = remember(line) { LyricRomanizationAligner.units(line) }
+    if (units.isEmpty()) {
+        MeloXGlyphLyricText(
+            line = line,
+            playbackTimeProvider = playbackTimeProvider,
+            supportsTimedLyrics = supportsTimedLyrics,
+            fontScale = fontScale,
+            reduceMotion = false,
+            timingEffectsStrength = 1f,
+            modifier = modifier,
+        )
+        return
+    }
+
+    val playbackTimeMs = playbackTimeProvider()
+    val primarySize = UpstreamLyrics.FONT_SIZE_SP * fontScale
+    val rubySize = max(primarySize * UpstreamLyrics.ROMANIZATION_FONT_SCALE, 13f)
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        units.forEach { unit ->
+            val reveal = if (!supportsTimedLyrics || unit.originalSyllables.isEmpty()) {
+                1f
+            } else {
+                val start = unit.originalSyllables.minOf { it.startTimeMs }
+                val end = unit.originalSyllables.maxOf { it.endTimeMs }.coerceAtLeast(start + 1L)
+                ((playbackTimeMs - start).toFloat() / (end - start).toFloat()).coerceIn(0f, 1f)
+            }
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = unit.originalText,
+                    color = Color.White.copy(alpha = if (supportsTimedLyrics) 0.3f + reveal * 0.7f else 1f),
+                    fontSize = primarySize.sp,
+                    lineHeight = (UpstreamLyrics.LINE_HEIGHT_SP * fontScale).sp,
+                    fontWeight = FontWeight.Black,
+                    maxLines = 1,
+                )
+                if (!unit.romanizationText.isNullOrBlank()) {
+                    Text(
+                        text = unit.romanizationText,
+                        color = Color.White.copy(alpha = UpstreamLyrics.ANNOTATION_OPACITY),
+                        fontSize = rubySize.sp,
+                        lineHeight = (rubySize * 1.2f).sp,
+                        fontWeight = FontWeight.Black,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}
+
 private data class MeloXGlyphVisual(
     val reveal: Float,
     val liftPx: Float,
     val scale: Float,
     val glow: Float,
 )
+
+private data class MeloXLyricInterlude(
+    val startTimeMs: Long,
+    val countdownEndTimeMs: Long,
+    val followingLyricTimeMs: Long,
+)
+
+private fun sourceLyricInterludes(lines: List<LyricLine>): List<MeloXLyricInterlude> = buildList {
+    lines.forEachIndexed { index, line ->
+        val start = if (index == 0) {
+            0L
+        } else {
+            val previous = lines[index - 1]
+            max(
+                previous.timeMs + (previous.durationMs ?: 0L),
+                previous.syllables.maxOfOrNull { it.endTimeMs } ?: previous.timeMs,
+            )
+        }
+        val countdownEnd = (line.timeMs - 250L).coerceAtLeast(start)
+        if (countdownEnd - start >= 4_000L) {
+            add(MeloXLyricInterlude(start, countdownEnd, line.timeMs))
+        }
+    }
+}
+
+@Composable
+private fun MeloXLyricInterludeCountdown(
+    interlude: MeloXLyricInterlude,
+    playbackTimeProvider: () -> Long,
+    reduceMotion: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(modifier.fillMaxWidth(0.28f).height(48.dp)) {
+        val now = playbackTimeProvider()
+        val duration = (interlude.countdownEndTimeMs - interlude.startTimeMs).coerceAtLeast(1L)
+        val elapsed = (now - interlude.startTimeMs).coerceIn(0L, duration)
+        val remaining = interlude.countdownEndTimeMs - now
+        if (remaining <= 0L) return@Canvas
+        val durationFloat = duration.toFloat()
+        val elapsedFloat = elapsed.toFloat()
+        val baseRadius = 5.dp.toPx()
+        val gap = 18.dp.toPx()
+        val centerY = size.height / 2f
+        repeat(3) { index ->
+            val segmentStart = durationFloat * index / 3f
+            val progress = ((elapsedFloat - segmentStart) / (durationFloat / 3f)).coerceIn(0.25f, 1f)
+            val fadeOut = (remaining / 375f).coerceIn(0f, 1f)
+            val breathe = if (reduceMotion) 1f else 1f +
+                sin(elapsed.toDouble() / 1_500.0 * 2.0 * Math.PI).toFloat() * 0.05f
+            drawCircle(
+                color = Color.White.copy(alpha = progress * fadeOut),
+                radius = baseRadius * breathe * if (index == 2) (1f + progress * 0.18f) else 1f,
+                center = Offset(baseRadius + index * gap, centerY),
+            )
+        }
+    }
+}
+
+private fun shareLyric(context: Context, state: MeloXPlaybackUiState, line: LyricLine) {
+    val songUrl = state.mediaId?.let { "https://music.163.com/song?id=$it" }.orEmpty()
+    val text = buildString {
+        append(line.text)
+        if (state.title.isNotBlank()) {
+            append("\n——《").append(state.title).append("》")
+            if (state.artist.isNotBlank()) append(" · ").append(state.artist)
+        }
+        if (songUrl.isNotBlank()) append('\n').append(songUrl)
+    }
+    val intent = Intent.createChooser(
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+        },
+        "分享歌词",
+    )
+    context.startActivity(intent)
+}
 
 /**
  * Compose counterpart of upstream LyricGlowTextRenderer.

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSMiniPlayer.kt
@@ -108,7 +108,7 @@ fun MeloXIOSMiniPlayer(
             with(sharedTransitionScope) {
                 Modifier.sharedBounds(
                     sharedContentState = rememberSharedContentState(
-                        key = sharedPlayerContainerKey(state.mediaId),
+                        key = sharedPlayerContainerKey(),
                     ),
                     animatedVisibilityScope = animatedVisibilityScope,
                     enter = EnterTransition.None,
@@ -150,6 +150,9 @@ fun MeloXIOSMiniPlayer(
                     surfaceColor = fallbackTint.copy(
                         alpha = fallbackTint.alpha * 0.40f,
                     ),
+                    // MiniPlayer keeps the liquid refraction/highlight, but its
+                    // background must remain sharp instead of blurring the list.
+                    blurRadius = 0.dp,
                 ),
         )
 
@@ -187,7 +190,7 @@ fun MeloXIOSMiniPlayer(
                         with(sharedTransitionScope) {
                             Modifier.sharedElement(
                                 sharedContentState = rememberSharedContentState(
-                                    key = sharedArtworkKey(state.mediaId),
+                                    key = sharedArtworkKey(),
                                 ),
                                 animatedVisibilityScope = animatedVisibilityScope,
                                 boundsTransform = MeloXPlayerLinearBoundsTransform,

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RectangleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -257,7 +258,12 @@ internal fun MeloXIOSNowPlayingScene(
                         scaleX = queueScale
                         scaleY = queueScale
                     }
-                    .padding(top = 80.dp),
+                    // Queue rows end above the persistent playback controls;
+                    // none of the list is hidden beneath the blurred control zone.
+                    .padding(
+                        top = 80.dp,
+                        bottom = MeloXNowPlayingControlsHeight.dp,
+                    ),
             ) {
                 MeloXQueuePanel(
                     state = state,
@@ -333,26 +339,26 @@ internal fun MeloXIOSNowPlayingScene(
         AnimatedVisibility(
             visible = page != MeloXNowPlayingPage.Lyrics || showsLyricsControls,
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(horizontal = 32.dp),
+                .align(Alignment.BottomCenter),
             enter = fadeIn(tween(220, easing = FastOutSlowInEasing)) +
                 slideInVertically(tween(260, easing = FastOutSlowInEasing)) { it / 8 },
             exit = fadeOut(tween(180, easing = FastOutSlowInEasing)) +
                 slideOutVertically(tween(220, easing = FastOutSlowInEasing)) { it / 8 },
         ) {
-            val controlsShape = RoundedCornerShape(28.dp)
             val controlsSurface = if (page != MeloXNowPlayingPage.Artwork) {
                 Modifier
                     .fillMaxWidth()
                     .height(MeloXNowPlayingControlsHeight.dp)
-                    .clip(controlsShape)
                     .meloXBackdropBlur(
-                        shape = controlsShape,
+                        shape = RectangleShape,
                         blurRadius = 24.dp,
                         surfaceColor = Color.Black.copy(alpha = .08f),
                     )
+                    .padding(horizontal = 32.dp)
             } else {
-                Modifier.fillMaxWidth()
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp)
             }
             Box(modifier = controlsSurface) {
                 MeloXNowPlayingCoreControls(

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingScene.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RectangleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -42,6 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
@@ -52,12 +52,14 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource.Companion.UserInput
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import com.lladlam.melox.ui.glass.LocalMeloXBackdrop
 import com.lladlam.melox.ui.settings.MeloXSettingsRuntime
+import com.lladlam.melox.ui.settings.MeloXSettingsPreferences
 import com.lladlam.melox.core.network.MeloXSearchKind
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -78,7 +80,17 @@ fun MeloXIOSNowPlayingSharedHost(
     // A track transition updates the content inside the existing player. It must
     // not recreate the page/gesture state or send the shared element back to its
     // MiniPlayer bounds while the full-screen player is still open.
-    var page by remember { mutableStateOf(MeloXNowPlayingPage.Artwork) }
+    val context = LocalContext.current.applicationContext
+    val rememberPlayerPage = MeloXSettingsPreferences.boolean(context, "playback_remember_page", true)
+    var page by remember(rememberPlayerPage) {
+        mutableStateOf(
+            if (rememberPlayerPage) runCatching {
+                MeloXNowPlayingPage.valueOf(
+                    MeloXSettingsPreferences.string(context, "playback_last_page", MeloXNowPlayingPage.Artwork.name),
+                )
+            }.getOrDefault(MeloXNowPlayingPage.Artwork) else MeloXNowPlayingPage.Artwork,
+        )
+    }
     var transitionSourcePage by remember {
         mutableStateOf(MeloXNowPlayingPage.Artwork)
     }
@@ -284,6 +296,9 @@ fun MeloXIOSNowPlayingSharedHost(
                                 if (destination != page) {
                                     transitionSourcePage = page
                                     page = destination
+                                    if (rememberPlayerPage) {
+                                        MeloXSettingsPreferences.setString(context, "playback_last_page", destination.name)
+                                    }
                                 }
                             },
                             onShowActions = {

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXIOSNowPlayingSharedHost.kt
@@ -75,14 +75,17 @@ fun MeloXIOSNowPlayingSharedHost(
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
-    var page by remember(state.mediaId) { mutableStateOf(MeloXNowPlayingPage.Artwork) }
-    var transitionSourcePage by remember(state.mediaId) {
+    // A track transition updates the content inside the existing player. It must
+    // not recreate the page/gesture state or send the shared element back to its
+    // MiniPlayer bounds while the full-screen player is still open.
+    var page by remember { mutableStateOf(MeloXNowPlayingPage.Artwork) }
+    var transitionSourcePage by remember {
         mutableStateOf(MeloXNowPlayingPage.Artwork)
     }
-    var showActions by remember(state.mediaId) { mutableStateOf(false) }
-    var showQuality by remember(state.mediaId) { mutableStateOf(false) }
-    var gestureCollapseProgress by remember(state.mediaId) { mutableFloatStateOf(0f) }
-    var settleJob by remember(state.mediaId) { mutableStateOf<Job?>(null) }
+    var showActions by remember { mutableStateOf(false) }
+    var showQuality by remember { mutableStateOf(false) }
+    var gestureCollapseProgress by remember { mutableFloatStateOf(0f) }
+    var settleJob by remember { mutableStateOf<Job?>(null) }
     val scope = rememberCoroutineScope()
     val hostView = LocalView.current
     DisposableEffect(MeloXSettingsRuntime.keepScreenOn) {
@@ -114,7 +117,7 @@ fun MeloXIOSNowPlayingSharedHost(
     val sharedContainerModifier = with(sharedTransitionScope) {
         Modifier.sharedBounds(
             sharedContentState = rememberSharedContentState(
-                key = sharedPlayerContainerKey(state.mediaId),
+                key = sharedPlayerContainerKey(),
             ),
             animatedVisibilityScope = animatedVisibilityScope,
             enter = EnterTransition.None,
@@ -407,7 +410,7 @@ private fun SharedArtworkDestination(
             val targetRadius = 12.dp
 
             val artworkSharedState = with(sharedTransitionScope) {
-                rememberSharedContentState(key = sharedArtworkKey(state.mediaId))
+                rememberSharedContentState(key = sharedArtworkKey())
             }
             val sharedModifier = with(sharedTransitionScope) {
                 Modifier.sharedElement(

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXPlayerTransitionKeys.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXPlayerTransitionKeys.kt
@@ -1,8 +1,5 @@
 package com.lladlam.melox.ui.player
 
-internal data class MeloXPlayerContainerKey(
-    val mediaId: String,
-)
+internal data object MeloXPlayerContainerKey
 
-internal fun sharedPlayerContainerKey(mediaId: String?): MeloXPlayerContainerKey =
-    MeloXPlayerContainerKey(mediaId.orEmpty())
+internal fun sharedPlayerContainerKey(): MeloXPlayerContainerKey = MeloXPlayerContainerKey

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXPlayerUi.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXPlayerUi.kt
@@ -95,6 +95,7 @@ class MeloXPlaybackUiState internal constructor(private val appContext: Context)
     private val downloadStore = MeloXDownloadStore.get(appContext)
     private val sleepTimerHandler = Handler(Looper.getMainLooper())
     private var sleepTimerRunnable: Runnable? = null
+    private var pendingMediaClearRunnable: Runnable? = null
 
     var mediaId by mutableStateOf<String?>(null)
         private set
@@ -157,6 +158,7 @@ class MeloXPlaybackUiState internal constructor(private val appContext: Context)
     }
 
     internal fun unbind() {
+        cancelPendingMediaClear()
         controller?.removeListener(listener)
         controller?.release()
         controller = null
@@ -166,6 +168,14 @@ class MeloXPlaybackUiState internal constructor(private val appContext: Context)
     internal fun refresh() {
         val player = controller ?: return
         val item = player.currentMediaItem
+        if (item == null) {
+            // MediaSession.setPlayer() briefly exposes an empty controller while
+            // AutoMix promotes the already-playing incoming deck. Clearing the UI
+            // in that gap collapses Now Playing and strands its back gesture.
+            if (mediaId != null) scheduleDeferredMediaClear(player) else clearMediaState(player)
+            return
+        }
+        cancelPendingMediaClear()
         val metadata = player.mediaMetadata.takeUnless { it == MediaMetadata.EMPTY }
             ?: item?.mediaMetadata
             ?: MediaMetadata.EMPTY
@@ -190,6 +200,42 @@ class MeloXPlaybackUiState internal constructor(private val appContext: Context)
         val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC).coerceAtLeast(1)
         volume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toFloat() / maxVolume.toFloat()
+        queue = buildQueue(player)
+    }
+
+    private fun scheduleDeferredMediaClear(player: Player) {
+        if (pendingMediaClearRunnable != null) return
+        val runnable = Runnable {
+            pendingMediaClearRunnable = null
+            val active = controller
+            if (active === player && active.currentMediaItem == null) {
+                clearMediaState(active)
+            } else {
+                refresh()
+            }
+        }
+        pendingMediaClearRunnable = runnable
+        sleepTimerHandler.postDelayed(runnable, MEDIA_CLEAR_GRACE_MS)
+    }
+
+    private fun cancelPendingMediaClear() {
+        pendingMediaClearRunnable?.let(sleepTimerHandler::removeCallbacks)
+        pendingMediaClearRunnable = null
+    }
+
+    private fun clearMediaState(player: Player) {
+        cancelPendingMediaClear()
+        mediaId = null
+        title = ""
+        artist = ""
+        album = ""
+        artworkUrl = null
+        isPlaying = false
+        positionMs = 0L
+        durationMs = 0L
+        hasPrevious = false
+        hasNext = false
+        currentIndex = player.currentMediaItemIndex
         queue = buildQueue(player)
     }
 
@@ -316,6 +362,10 @@ class MeloXPlaybackUiState internal constructor(private val appContext: Context)
         sleepTimerRunnable?.let(sleepTimerHandler::removeCallbacks)
         sleepTimerRunnable = null
         sleepTimerEndRealtimeMs = 0L
+    }
+
+    private companion object {
+        const val MEDIA_CLEAR_GRACE_MS = 500L
     }
 }
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXSharedTransitions.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/player/MeloXSharedTransitions.kt
@@ -1,8 +1,5 @@
 package com.lladlam.melox.ui.player
 
-internal data class MeloXSharedArtworkKey(
-    val mediaId: String,
-)
+internal data object MeloXSharedArtworkKey
 
-internal fun sharedArtworkKey(mediaId: String?): MeloXSharedArtworkKey =
-    MeloXSharedArtworkKey(mediaId.orEmpty())
+internal fun sharedArtworkKey(): MeloXSharedArtworkKey = MeloXSharedArtworkKey

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/MeloXSettingsPreferences.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/MeloXSettingsPreferences.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
 enum class MeloXThemeMode { System, Light, Dark }
+enum class MeloXLyricAnnotationDisplayMode { FocusedLine, AllLines }
 
 /** Process-visible settings used by UI paths that need immediate recomposition. */
 object MeloXSettingsRuntime {
@@ -31,11 +32,23 @@ object MeloXSettingsRuntime {
         internal set
     var lyricTapSeekEnabled by mutableStateOf(true)
         internal set
+    var lyricLongPressShareEnabled by mutableStateOf(true)
+        internal set
+    var lyricInterludeCountdownEnabled by mutableStateOf(true)
+        internal set
     var lyricAutoFollowEnabled by mutableStateOf(true)
         internal set
     var lyricReduceMotion by mutableStateOf(false)
         internal set
     var lyricAdvanceMs by mutableStateOf(0)
+        internal set
+    var lyricAdvanceAppliesToWordByWord by mutableStateOf(false)
+        internal set
+    var lyricRefreshRate by mutableStateOf(60)
+        internal set
+    var lyricRomanizationDisplayMode by mutableStateOf(MeloXLyricAnnotationDisplayMode.FocusedLine)
+        internal set
+    var lyricTranslationDisplayMode by mutableStateOf(MeloXLyricAnnotationDisplayMode.FocusedLine)
         internal set
     var lyricFollowDelayMs by mutableStateOf(3_000)
         internal set
@@ -77,9 +90,16 @@ object MeloXSettingsRuntime {
         lyricWordByWordEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_word_by_word", true)
         lyricPseudoTimingEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_pseudo_timing", true)
         lyricTapSeekEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_tap_seek", true)
+        lyricLongPressShareEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_long_press_share", true)
+        lyricInterludeCountdownEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_interlude_countdown", true)
         lyricAutoFollowEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_auto_follow", true)
         lyricReduceMotion = MeloXSettingsPreferences.boolean(app, "lyrics_reduce_motion", false)
-        lyricAdvanceMs = MeloXSettingsPreferences.int(app, "lyrics_advance_ms", 0).coerceIn(-1_000, 1_000)
+        lyricAdvanceMs = MeloXSettingsPreferences.int(app, "lyrics_advance_ms", 0).coerceIn(-5_000, 5_000)
+        lyricAdvanceAppliesToWordByWord = MeloXSettingsPreferences.boolean(app, "lyrics_advance_word_by_word", false)
+        lyricRefreshRate = MeloXSettingsPreferences.int(app, "lyrics_refresh_rate", 60)
+            .takeIf { it in setOf(30, 60, 90, 120) } ?: 60
+        lyricRomanizationDisplayMode = annotationMode(app, "lyrics_romanization_display_mode")
+        lyricTranslationDisplayMode = annotationMode(app, "lyrics_translation_display_mode")
         lyricFollowDelayMs = MeloXSettingsPreferences.int(app, "lyrics_follow_delay_ms", 3_000).coerceIn(1_000, 8_000)
         lyricFontScale = MeloXSettingsPreferences.float(app, "lyrics_font_scale", 1f).coerceIn(.8f, 1.25f)
         lyricSpacingScale = MeloXSettingsPreferences.float(app, "lyrics_spacing_scale", 1f).coerceIn(.7f, 1.5f)
@@ -91,6 +111,12 @@ object MeloXSettingsRuntime {
         downloadLyricsEnabled = MeloXSettingsPreferences.boolean(app, "download_lyrics", true)
         musicArea = MeloXSettingsPreferences.string(app, "music_area", "全部")
     }
+
+    private fun annotationMode(context: Context, key: String): MeloXLyricAnnotationDisplayMode = runCatching {
+        MeloXLyricAnnotationDisplayMode.valueOf(
+            MeloXSettingsPreferences.string(context, key, MeloXLyricAnnotationDisplayMode.FocusedLine.name),
+        )
+    }.getOrDefault(MeloXLyricAnnotationDisplayMode.FocusedLine)
 }
 
 object MeloXSettingsPreferences {
@@ -126,8 +152,11 @@ object MeloXSettingsPreferences {
             "lyrics_word_by_word" -> MeloXSettingsRuntime.lyricWordByWordEnabled = value
             "lyrics_pseudo_timing" -> MeloXSettingsRuntime.lyricPseudoTimingEnabled = value
             "lyrics_tap_seek" -> MeloXSettingsRuntime.lyricTapSeekEnabled = value
+            "lyrics_long_press_share" -> MeloXSettingsRuntime.lyricLongPressShareEnabled = value
+            "lyrics_interlude_countdown" -> MeloXSettingsRuntime.lyricInterludeCountdownEnabled = value
             "lyrics_auto_follow" -> MeloXSettingsRuntime.lyricAutoFollowEnabled = value
             "lyrics_reduce_motion" -> MeloXSettingsRuntime.lyricReduceMotion = value
+            "lyrics_advance_word_by_word" -> MeloXSettingsRuntime.lyricAdvanceAppliesToWordByWord = value
             "tab_home" -> MeloXSettingsRuntime.homeTabEnabled = value
             "tab_explore" -> MeloXSettingsRuntime.exploreTabEnabled = value
             "tab_library" -> MeloXSettingsRuntime.libraryTabEnabled = value
@@ -139,8 +168,10 @@ object MeloXSettingsPreferences {
     fun setInt(context: Context, key: String, value: Int) {
         prefs(context).edit().putInt(key, value).apply()
         when (key) {
-            "lyrics_advance_ms" -> MeloXSettingsRuntime.lyricAdvanceMs = value.coerceIn(-1_000, 1_000)
+            "lyrics_advance_ms" -> MeloXSettingsRuntime.lyricAdvanceMs = value.coerceIn(-5_000, 5_000)
             "lyrics_follow_delay_ms" -> MeloXSettingsRuntime.lyricFollowDelayMs = value.coerceIn(1_000, 8_000)
+            "lyrics_refresh_rate" -> MeloXSettingsRuntime.lyricRefreshRate =
+                value.takeIf { it in setOf(30, 60, 90, 120) } ?: 60
         }
     }
 
@@ -160,6 +191,12 @@ object MeloXSettingsPreferences {
                 MeloXThemeMode.valueOf(value)
             }.getOrDefault(MeloXThemeMode.System)
             "music_area" -> MeloXSettingsRuntime.musicArea = value
+            "lyrics_romanization_display_mode" -> MeloXSettingsRuntime.lyricRomanizationDisplayMode = runCatching {
+                MeloXLyricAnnotationDisplayMode.valueOf(value)
+            }.getOrDefault(MeloXLyricAnnotationDisplayMode.FocusedLine)
+            "lyrics_translation_display_mode" -> MeloXSettingsRuntime.lyricTranslationDisplayMode = runCatching {
+                MeloXLyricAnnotationDisplayMode.valueOf(value)
+            }.getOrDefault(MeloXLyricAnnotationDisplayMode.FocusedLine)
         }
     }
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/MeloXSettingsPreferences.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/MeloXSettingsPreferences.kt
@@ -25,11 +25,37 @@ object MeloXSettingsRuntime {
         internal set
     var showLyricRomanization by mutableStateOf(true)
         internal set
+    var lyricWordByWordEnabled by mutableStateOf(true)
+        internal set
+    var lyricPseudoTimingEnabled by mutableStateOf(true)
+        internal set
+    var lyricTapSeekEnabled by mutableStateOf(true)
+        internal set
+    var lyricAutoFollowEnabled by mutableStateOf(true)
+        internal set
+    var lyricReduceMotion by mutableStateOf(false)
+        internal set
+    var lyricAdvanceMs by mutableStateOf(0)
+        internal set
+    var lyricFollowDelayMs by mutableStateOf(3_000)
+        internal set
+    var lyricFontScale by mutableStateOf(1f)
+        internal set
+    var lyricSpacingScale by mutableStateOf(1f)
+        internal set
+    var lyricBlurStrength by mutableStateOf(1f)
+        internal set
+    var homeTabEnabled by mutableStateOf(true)
+        internal set
+    var exploreTabEnabled by mutableStateOf(true)
+        internal set
+    var libraryTabEnabled by mutableStateOf(true)
+        internal set
+    var rememberLastTab by mutableStateOf(true)
+        internal set
     var downloadLyricsEnabled by mutableStateOf(true)
         internal set
     var musicArea by mutableStateOf("全部")
-        internal set
-    var beatNetDebugEnabled by mutableStateOf(false)
         internal set
 
     private var initialized = false
@@ -48,9 +74,22 @@ object MeloXSettingsRuntime {
         keepScreenOn = MeloXSettingsPreferences.boolean(app, "player_keep_screen_on", false)
         showLyricTranslation = MeloXSettingsPreferences.boolean(app, "lyrics_translation", true)
         showLyricRomanization = MeloXSettingsPreferences.boolean(app, "lyrics_romanization", true)
+        lyricWordByWordEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_word_by_word", true)
+        lyricPseudoTimingEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_pseudo_timing", true)
+        lyricTapSeekEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_tap_seek", true)
+        lyricAutoFollowEnabled = MeloXSettingsPreferences.boolean(app, "lyrics_auto_follow", true)
+        lyricReduceMotion = MeloXSettingsPreferences.boolean(app, "lyrics_reduce_motion", false)
+        lyricAdvanceMs = MeloXSettingsPreferences.int(app, "lyrics_advance_ms", 0).coerceIn(-1_000, 1_000)
+        lyricFollowDelayMs = MeloXSettingsPreferences.int(app, "lyrics_follow_delay_ms", 3_000).coerceIn(1_000, 8_000)
+        lyricFontScale = MeloXSettingsPreferences.float(app, "lyrics_font_scale", 1f).coerceIn(.8f, 1.25f)
+        lyricSpacingScale = MeloXSettingsPreferences.float(app, "lyrics_spacing_scale", 1f).coerceIn(.7f, 1.5f)
+        lyricBlurStrength = MeloXSettingsPreferences.float(app, "lyrics_blur_strength", 1f).coerceIn(0f, 1.5f)
+        homeTabEnabled = MeloXSettingsPreferences.boolean(app, "tab_home", true)
+        exploreTabEnabled = MeloXSettingsPreferences.boolean(app, "tab_explore", true)
+        libraryTabEnabled = MeloXSettingsPreferences.boolean(app, "tab_library", true)
+        rememberLastTab = MeloXSettingsPreferences.boolean(app, "general_remember_tab", true)
         downloadLyricsEnabled = MeloXSettingsPreferences.boolean(app, "download_lyrics", true)
         musicArea = MeloXSettingsPreferences.string(app, "music_area", "全部")
-        beatNetDebugEnabled = MeloXSettingsPreferences.boolean(app, "developer_beatnet", false)
     }
 }
 
@@ -68,6 +107,12 @@ object MeloXSettingsPreferences {
     fun string(context: Context, key: String, default: String = ""): String =
         prefs(context).getString(key, default) ?: default
 
+    fun int(context: Context, key: String, default: Int = 0): Int =
+        prefs(context).getInt(key, default)
+
+    fun float(context: Context, key: String, default: Float = 0f): Float =
+        prefs(context).getFloat(key, default)
+
     fun setBoolean(context: Context, key: String, value: Boolean) {
         prefs(context).edit().putBoolean(key, value).apply()
         when (key) {
@@ -78,8 +123,33 @@ object MeloXSettingsPreferences {
             "player_keep_screen_on" -> MeloXSettingsRuntime.keepScreenOn = value
             "lyrics_translation" -> MeloXSettingsRuntime.showLyricTranslation = value
             "lyrics_romanization" -> MeloXSettingsRuntime.showLyricRomanization = value
+            "lyrics_word_by_word" -> MeloXSettingsRuntime.lyricWordByWordEnabled = value
+            "lyrics_pseudo_timing" -> MeloXSettingsRuntime.lyricPseudoTimingEnabled = value
+            "lyrics_tap_seek" -> MeloXSettingsRuntime.lyricTapSeekEnabled = value
+            "lyrics_auto_follow" -> MeloXSettingsRuntime.lyricAutoFollowEnabled = value
+            "lyrics_reduce_motion" -> MeloXSettingsRuntime.lyricReduceMotion = value
+            "tab_home" -> MeloXSettingsRuntime.homeTabEnabled = value
+            "tab_explore" -> MeloXSettingsRuntime.exploreTabEnabled = value
+            "tab_library" -> MeloXSettingsRuntime.libraryTabEnabled = value
+            "general_remember_tab" -> MeloXSettingsRuntime.rememberLastTab = value
             "download_lyrics" -> MeloXSettingsRuntime.downloadLyricsEnabled = value
-            "developer_beatnet" -> MeloXSettingsRuntime.beatNetDebugEnabled = value
+        }
+    }
+
+    fun setInt(context: Context, key: String, value: Int) {
+        prefs(context).edit().putInt(key, value).apply()
+        when (key) {
+            "lyrics_advance_ms" -> MeloXSettingsRuntime.lyricAdvanceMs = value.coerceIn(-1_000, 1_000)
+            "lyrics_follow_delay_ms" -> MeloXSettingsRuntime.lyricFollowDelayMs = value.coerceIn(1_000, 8_000)
+        }
+    }
+
+    fun setFloat(context: Context, key: String, value: Float) {
+        prefs(context).edit().putFloat(key, value).apply()
+        when (key) {
+            "lyrics_font_scale" -> MeloXSettingsRuntime.lyricFontScale = value.coerceIn(.8f, 1.25f)
+            "lyrics_spacing_scale" -> MeloXSettingsRuntime.lyricSpacingScale = value.coerceIn(.7f, 1.5f)
+            "lyrics_blur_strength" -> MeloXSettingsRuntime.lyricBlurStrength = value.coerceIn(0f, 1.5f)
         }
     }
 

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/SettingsScreen.kt
@@ -48,6 +48,11 @@ import com.lladlam.melox.core.audio.MusicQuality
 import com.lladlam.melox.core.audio.MusicQualityPreferences
 import com.lladlam.melox.core.download.MeloXDownloadStore
 import com.lladlam.melox.playback.PlaybackCommands
+import com.lladlam.melox.playback.MeloXAutoMixFadeCurve
+import com.lladlam.melox.playback.MeloXAutoMixFallback
+import com.lladlam.melox.playback.MeloXAutoMixMode
+import com.lladlam.melox.playback.MeloXAutoMixSettings
+import com.lladlam.melox.playback.MeloXPlaybackModePreferences
 import com.lladlam.melox.ui.MeloXBottomContentClearance
 import com.lladlam.melox.ui.glass.meloXLiquidButton
 import kotlinx.coroutines.Dispatchers
@@ -101,7 +106,7 @@ private val SettingsSections = listOf(
     )),
     SettingsSection("关于与开发", listOf(
         SettingsItem(SettingsRoute.About, "版本、项目主页与开源信息", "ⓘ", "GitHub 更新 开源 许可"),
-        SettingsItem(SettingsRoute.Developer, "BeatNet 与播放器调试工具", "⌘", "BeatNet 节拍 调试"),
+        SettingsItem(SettingsRoute.Developer, "播放器诊断与迁移状态", "⌘", "BeatNet 节拍 调试 日志"),
     )),
 )
 
@@ -360,7 +365,7 @@ private fun SettingsDetailScreen(route: SettingsRoute, onBack: () -> Unit) {
             SettingsRoute.TabLayout -> TabLayoutSettings(context)
             SettingsRoute.General -> GeneralSettings(context)
             SettingsRoute.About -> AboutSettings(context)
-            SettingsRoute.Developer -> DeveloperSettings(context)
+            SettingsRoute.Developer -> DeveloperSettings()
         }
     }
 }
@@ -380,8 +385,114 @@ private fun PlaybackSettings(context: android.content.Context) {
     }
     Spacer(Modifier.height(22.dp))
     SettingsToggleRow(context, "记住播放器上次页面", "playback_remember_page", true)
-    SettingsToggleRow(context, "耳机断开时暂停", "playback_pause_disconnect", true)
-    SettingsToggleRow(context, "自动混音", "playback_auto_mix", false, "当前 Media3 队列暂不执行交叉淡化；偏好会保留。")
+    SettingsInfoCard("耳机断开时暂停", "已由 Media3 播放服务启用")
+    Spacer(Modifier.height(10.dp))
+    val legacyAutoMix = remember { MeloXSettingsPreferences.boolean(context, "playback_auto_mix", false) }
+    var autoMixEnabled by remember {
+        mutableStateOf(MeloXPlaybackModePreferences.autoMix(context) || legacyAutoMix)
+    }
+    LaunchedEffect(legacyAutoMix) {
+        if (legacyAutoMix) {
+            MeloXPlaybackModePreferences.setAutoMix(context, true)
+            MeloXSettingsPreferences.setBoolean(context, "playback_auto_mix", false)
+        }
+    }
+    SettingsExternalToggleRow(
+        title = "自动混音",
+        value = autoMixEnabled,
+        note = "双播放器预载，20ms 包络更新；分析不可用时按下方策略平滑降级。",
+    ) {
+        autoMixEnabled = it
+        MeloXPlaybackModePreferences.setAutoMix(context, it)
+    }
+    if (autoMixEnabled) AutoMixSettings(context)
+}
+
+@Composable
+private fun AutoMixSettings(context: android.content.Context) {
+    var settings by remember { mutableStateOf(MeloXAutoMixSettings.read(context)) }
+    fun refresh() { settings = MeloXAutoMixSettings.read(context) }
+
+    Text("混音模式", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        listOf(MeloXAutoMixMode.Smart to "智能", MeloXAutoMixMode.Fixed to "固定时长").forEach { (mode, title) ->
+            SettingsChoiceRow(title, settings.mode == mode) {
+                MeloXPlaybackModePreferences.setAutoMixString(context, "automix_mode", mode.name)
+                refresh()
+            }
+        }
+    }
+    Spacer(Modifier.height(14.dp))
+    if (settings.mode == MeloXAutoMixMode.Smart) {
+        Text("智能过渡长度", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+        Spacer(Modifier.height(8.dp))
+        SettingsGlassGroup {
+            listOf(4, 8, 16).forEach { bars ->
+                SettingsChoiceRow("$bars 小节", settings.transitionBars == bars) {
+                    MeloXPlaybackModePreferences.setAutoMixInt(context, "automix_transition_bars", bars)
+                    refresh()
+                }
+            }
+        }
+        Spacer(Modifier.height(14.dp))
+    }
+    Text("交叉淡化时长", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        listOf(3_000L, 6_000L, 8_000L, 12_000L).forEach { duration ->
+            SettingsChoiceRow("${duration / 1_000} 秒", settings.fixedDurationMs == duration) {
+                MeloXPlaybackModePreferences.setAutoMixLong(context, "automix_fixed_duration_ms", duration)
+                refresh()
+            }
+        }
+    }
+    Spacer(Modifier.height(14.dp))
+    Text("预加载提前量", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        listOf(30_000L, 60_000L, 90_000L, 120_000L).forEach { lead ->
+            SettingsChoiceRow("${lead / 1_000} 秒", settings.preloadLeadMs == lead) {
+                MeloXPlaybackModePreferences.setAutoMixLong(context, "automix_preload_lead_ms", lead)
+                refresh()
+            }
+        }
+    }
+    Spacer(Modifier.height(14.dp))
+    Text("淡化曲线", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        listOf(
+            MeloXAutoMixFadeCurve.EqualPower to "等功率",
+            MeloXAutoMixFadeCurve.Smooth to "平滑",
+            MeloXAutoMixFadeCurve.Linear to "线性",
+        ).forEach { (curve, title) ->
+            SettingsChoiceRow(title, settings.fadeCurve == curve) {
+                MeloXPlaybackModePreferences.setAutoMixString(context, "automix_fade_curve", curve.name)
+                refresh()
+            }
+        }
+    }
+    Spacer(Modifier.height(14.dp))
+    Text("分析失败时", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        listOf(
+            MeloXAutoMixFallback.Crossfade to "使用所选时长",
+            MeloXAutoMixFallback.ShortCrossfade to "短淡化（3 秒）",
+            MeloXAutoMixFallback.Normal to "正常切歌",
+        ).forEach { (fallback, title) ->
+            SettingsChoiceRow(title, settings.fallback == fallback) {
+                MeloXPlaybackModePreferences.setAutoMixString(context, "automix_fallback", fallback.name)
+                refresh()
+            }
+        }
+    }
+    Spacer(Modifier.height(14.dp))
+    SettingsExternalToggleRow("速度匹配", settings.tempoMatching, "有可靠 BPM 分析时，最多调整 5%。") {
+        MeloXPlaybackModePreferences.setAutoMixBoolean(context, "automix_tempo_matching", it)
+        refresh()
+    }
 }
 
 @Composable
@@ -396,15 +507,73 @@ private fun LyricsSettings(context: android.content.Context) {
     SettingsToggleRow(context, "显示翻译", "lyrics_translation", true)
     SettingsToggleRow(context, "显示罗马音", "lyrics_romanization", true)
     SettingsToggleRow(context, "逐字歌词（YRC）", "lyrics_word_by_word", true)
+    SettingsToggleRow(context, "普通 LRC 生成逐字时间", "lyrics_pseudo_timing", true, "按 Unicode 字素分配行时长，不覆盖真实 YRC。")
     SettingsToggleRow(context, "点击歌词跳转进度", "lyrics_tap_seek", true)
+    SettingsToggleRow(context, "自动跟随当前歌词", "lyrics_auto_follow", true)
+    SettingsToggleRow(context, "减弱歌词动画", "lyrics_reduce_motion", false, "保留逐字高亮，关闭弹性、抬升与光晕。")
+
+    LyricsChoiceSetting(context, "歌词时间偏移", "lyrics_advance_ms", 0, listOf(-400, -200, 0, 200, 400)) { value ->
+        if (value == 0) "同步" else if (value > 0) "提前 ${value}ms" else "延后 ${-value}ms"
+    }
+    LyricsChoiceSetting(context, "手动滚动后恢复跟随", "lyrics_follow_delay_ms", 3_000, listOf(1_500, 3_000, 5_000, 8_000)) { "${it / 1_000f} 秒" }
+    LyricsFloatChoiceSetting(context, "歌词字号", "lyrics_font_scale", 1f, listOf(.85f, 1f, 1.12f, 1.25f)) { "${(it * 100).toInt()}%" }
+    LyricsFloatChoiceSetting(context, "行间距", "lyrics_spacing_scale", 1f, listOf(.8f, 1f, 1.2f, 1.4f)) { "${(it * 100).toInt()}%" }
+    LyricsFloatChoiceSetting(context, "远近模糊", "lyrics_blur_strength", 1f, listOf(0f, .6f, 1f, 1.4f)) { if (it == 0f) "关闭" else "${(it * 100).toInt()}%" }
+}
+
+@Composable
+private fun LyricsChoiceSetting(
+    context: android.content.Context,
+    title: String,
+    key: String,
+    default: Int,
+    values: List<Int>,
+    label: (Int) -> String,
+) {
+    var selected by remember(key) { mutableStateOf(MeloXSettingsPreferences.int(context, key, default)) }
+    Text(title, modifier = Modifier.padding(top = 8.dp), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        values.forEach { value ->
+            SettingsChoiceRow(label(value), selected == value) {
+                selected = value
+                MeloXSettingsPreferences.setInt(context, key, value)
+            }
+        }
+    }
+    Spacer(Modifier.height(10.dp))
+}
+
+@Composable
+private fun LyricsFloatChoiceSetting(
+    context: android.content.Context,
+    title: String,
+    key: String,
+    default: Float,
+    values: List<Float>,
+    label: (Float) -> String,
+) {
+    var selected by remember(key) { mutableStateOf(MeloXSettingsPreferences.float(context, key, default)) }
+    Text(title, modifier = Modifier.padding(top = 8.dp), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        values.forEach { value ->
+            SettingsChoiceRow(label(value), kotlin.math.abs(selected - value) < .001f) {
+                selected = value
+                MeloXSettingsPreferences.setFloat(context, key, value)
+            }
+        }
+    }
+    Spacer(Modifier.height(10.dp))
 }
 
 @Composable
 private fun ContentFeatureSettings(context: android.content.Context) {
     SettingsToggleRow(context, "播客", "feature_podcasts", true)
     SettingsToggleRow(context, "最近播放", "feature_history", true)
-    SettingsToggleRow(context, "云盘", "feature_cloud", true)
-    SettingsToggleRow(context, "下载", "feature_downloads", true, "歌曲更多菜单支持下载、取消和删除；播放时优先使用本地文件。")
+    SettingsInfoCard("下载", "已启用 · 更多菜单可下载，播放优先本地文件")
+    Spacer(Modifier.height(10.dp))
+    SettingsInfoCard("云盘", "尚未迁移，暂不显示无效开关")
 }
 
 @Composable
@@ -421,8 +590,7 @@ private fun ContentSettings(context: android.content.Context) {
         }
     }
     Spacer(Modifier.height(20.dp))
-    SettingsToggleRow(context, "显示歌单播放量", "content_playlist_play_count", true)
-    SettingsToggleRow(context, "发现页显示精品歌单", "content_high_quality_playlist", true)
+    SettingsInfoCard("内容展示", "播放量与精品歌单开关尚未接入数据层，暂不提供无效选项")
 }
 
 @Composable
@@ -441,7 +609,8 @@ private fun StorageSettings(context: android.content.Context) {
     SettingsInfoCard("已下载歌曲", "${downloads.downloads.size} 首 · ${formatBytes(downloads.totalByteCount)}")
     Spacer(Modifier.height(14.dp))
 
-    SettingsToggleRow(context, "按播放次数自动缓存", "downloads_auto_cache", false, "与上游 DownloadStore 对齐的自动缓存偏好；手动下载始终可用。")
+    SettingsInfoCard("自动缓存", "尚未迁移播放次数策略；手动下载始终可用")
+    Spacer(Modifier.height(10.dp))
     SettingsToggleRow(context, "下载歌词", "download_lyrics", true, "下载歌曲时同时保存歌词；默认开启，可在此关闭。封面始终随歌曲保存。")
 
     if (downloads.activeDownloads.isNotEmpty()) {
@@ -500,7 +669,7 @@ private fun TabLayoutSettings(context: android.content.Context) {
     SettingsToggleRow(context, "首页", "tab_home", true)
     SettingsToggleRow(context, "发现", "tab_explore", true)
     SettingsToggleRow(context, "音乐库", "tab_library", true)
-    SettingsToggleRow(context, "记住音乐库页面", "library_remember_page", true)
+    SettingsInfoCard("标签栏", "页面开关立即生效；设置与搜索始终保留")
     Text("搜索保持为独立的右侧 Liquid Glass 按钮。", modifier = Modifier.padding(top = 12.dp), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .46f))
 }
 
@@ -522,8 +691,8 @@ private fun GeneralSettings(context: android.content.Context) {
         }
     }
     Spacer(Modifier.height(20.dp))
-    SettingsToggleRow(context, "识别剪贴板中的网易云链接", "general_clipboard_links", true)
     SettingsToggleRow(context, "记住上次标签页", "general_remember_tab", true)
+    SettingsInfoCard("剪贴板链接识别", "尚未迁移 Android 前台生命周期处理，暂不提供无效开关")
 }
 
 @Composable
@@ -571,10 +740,10 @@ private fun AboutSettings(context: android.content.Context) {
 }
 
 @Composable
-private fun DeveloperSettings(context: android.content.Context) {
-    SettingsToggleRow(context, "BeatNet 调试入口", "developer_beatnet", false)
-    SettingsToggleRow(context, "显示播放器调试信息", "developer_player_debug", false)
-    SettingsToggleRow(context, "记录网络请求错误", "developer_network_log", true)
+private fun DeveloperSettings() {
+    SettingsInfoCard("BeatNet", "上游 CoreML 模型不能直接在 Android 运行；当前智能模式会使用可用分析，否则按降级策略切歌")
+    Spacer(Modifier.height(10.dp))
+    SettingsInfoCard("播放器与网络日志", "使用 Logcat 的 MeloXPlayback / 网络标签；不再保存无效偏好")
 }
 
 @Composable
@@ -608,6 +777,25 @@ private fun SettingsToggleRow(
                 value = it
                 MeloXSettingsPreferences.setBoolean(context, key, it)
             })
+        }
+    }
+    Spacer(Modifier.height(10.dp))
+}
+
+@Composable
+private fun SettingsExternalToggleRow(
+    title: String,
+    value: Boolean,
+    note: String? = null,
+    onValueChange: (Boolean) -> Unit,
+) {
+    SettingsGlassGroup {
+        Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(title, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+                note?.let { Text(it, modifier = Modifier.padding(top = 3.dp), fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .45f)) }
+            }
+            Switch(checked = value, onCheckedChange = onValueChange)
         }
     }
     Spacer(Modifier.height(10.dp))
@@ -670,6 +858,7 @@ private fun SettingsResetCard() {
     val context = LocalContext.current
     SettingsDangerButton("恢复播放器默认设置") {
         MeloXSettingsPreferences.reset(context)
+        MeloXPlaybackModePreferences.reset(context)
         PlaybackCommands.changeQuality(context, MusicQuality.Standard)
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/settings/SettingsScreen.kt
@@ -506,19 +506,60 @@ private fun PlayerAppearanceSettings(context: android.content.Context) {
 private fun LyricsSettings(context: android.content.Context) {
     SettingsToggleRow(context, "显示翻译", "lyrics_translation", true)
     SettingsToggleRow(context, "显示罗马音", "lyrics_romanization", true)
+    LyricsStringChoiceSetting(
+        context,
+        "罗马音显示范围",
+        "lyrics_romanization_display_mode",
+        MeloXLyricAnnotationDisplayMode.FocusedLine.name,
+        MeloXLyricAnnotationDisplayMode.entries.map { it.name },
+    ) { if (it == MeloXLyricAnnotationDisplayMode.FocusedLine.name) "仅当前播放行" else "全部歌词行" }
+    LyricsStringChoiceSetting(
+        context,
+        "翻译显示范围",
+        "lyrics_translation_display_mode",
+        MeloXLyricAnnotationDisplayMode.FocusedLine.name,
+        MeloXLyricAnnotationDisplayMode.entries.map { it.name },
+    ) { if (it == MeloXLyricAnnotationDisplayMode.FocusedLine.name) "仅当前播放行" else "全部歌词行" }
     SettingsToggleRow(context, "逐字歌词（YRC）", "lyrics_word_by_word", true)
     SettingsToggleRow(context, "普通 LRC 生成逐字时间", "lyrics_pseudo_timing", true, "按 Unicode 字素分配行时长，不覆盖真实 YRC。")
     SettingsToggleRow(context, "点击歌词跳转进度", "lyrics_tap_seek", true)
+    SettingsToggleRow(context, "长按歌词分享", "lyrics_long_press_share", true)
+    SettingsToggleRow(context, "间奏倒计时", "lyrics_interlude_countdown", true, "歌词间隔至少 4 秒时显示三点倒计时。")
     SettingsToggleRow(context, "自动跟随当前歌词", "lyrics_auto_follow", true)
     SettingsToggleRow(context, "减弱歌词动画", "lyrics_reduce_motion", false, "保留逐字高亮，关闭弹性、抬升与光晕。")
 
-    LyricsChoiceSetting(context, "歌词时间偏移", "lyrics_advance_ms", 0, listOf(-400, -200, 0, 200, 400)) { value ->
+    LyricsChoiceSetting(context, "歌词提前量", "lyrics_advance_ms", 0, listOf(-1_000, -500, -200, 0, 200, 500, 1_000, 2_000, 5_000)) { value ->
         if (value == 0) "同步" else if (value > 0) "提前 ${value}ms" else "延后 ${-value}ms"
     }
+    SettingsToggleRow(context, "提前量同时应用于逐字高亮", "lyrics_advance_word_by_word", false)
+    LyricsChoiceSetting(context, "歌词刷新率", "lyrics_refresh_rate", 60, listOf(30, 60, 90, 120)) { "$it FPS" }
     LyricsChoiceSetting(context, "手动滚动后恢复跟随", "lyrics_follow_delay_ms", 3_000, listOf(1_500, 3_000, 5_000, 8_000)) { "${it / 1_000f} 秒" }
     LyricsFloatChoiceSetting(context, "歌词字号", "lyrics_font_scale", 1f, listOf(.85f, 1f, 1.12f, 1.25f)) { "${(it * 100).toInt()}%" }
     LyricsFloatChoiceSetting(context, "行间距", "lyrics_spacing_scale", 1f, listOf(.8f, 1f, 1.2f, 1.4f)) { "${(it * 100).toInt()}%" }
     LyricsFloatChoiceSetting(context, "远近模糊", "lyrics_blur_strength", 1f, listOf(0f, .6f, 1f, 1.4f)) { if (it == 0f) "关闭" else "${(it * 100).toInt()}%" }
+}
+
+@Composable
+private fun LyricsStringChoiceSetting(
+    context: android.content.Context,
+    title: String,
+    key: String,
+    default: String,
+    values: List<String>,
+    label: (String) -> String,
+) {
+    var selected by remember(key) { mutableStateOf(MeloXSettingsPreferences.string(context, key, default)) }
+    Text(title, modifier = Modifier.padding(top = 8.dp), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = .48f))
+    Spacer(Modifier.height(8.dp))
+    SettingsGlassGroup {
+        values.forEach { value ->
+            SettingsChoiceRow(label(value), selected == value) {
+                selected = value
+                MeloXSettingsPreferences.setString(context, key, value)
+            }
+        }
+    }
+    Spacer(Modifier.height(10.dp))
 }
 
 @Composable


### PR DESCRIPTION
## What changed

### Player presentation and stability
- keep MiniPlayer liquid-glass refraction while disabling its background blur
- extend Lyrics/Queue playback-control blur across the full control region
- preserve Now Playing state when the media ID changes

### AutoMix
- reuse persistent dual ExoPlayer decks and drive the envelope from media clocks
- add Smart/Fixed planning, selectable fade curves, preload lead, fallback modes and optional tempo envelopes
- route settings through the preferences actually consumed by the playback service
- increase configurable preload lead to reduce handoff-edge stalls
- reset player rate and envelope state safely after completion or cancellation
- use the configured fallback when Android-side musical analysis is unavailable

### Lyrics rendering and scrolling
- render only visible lyric rows with LazyColumn
- keep the 60 Hz syllable clock in the Canvas draw phase
- preserve real YRC syllable timing and generate grapheme-safe pseudo timing for ordinary LRC
- activate a line from its first real syllable so the next line does not dim early
- make word-by-word rendering, tap-to-seek, auto-follow, reduce-motion, timing offset, font, spacing and blur settings effective
- retain interruptible per-line cascade motion while shortening Android animation timing
- combine stacked row blur effects to reduce GPU work and flashing

### Settings
- expose working AutoMix and lyric controls
- make root-tab visibility and last-tab/player-page memory effective
- replace inert switches with honest capability/status rows
- document that upstream BeatNet is CoreML-only and requires an Android model before native smart analysis can be enabled

## Root cause

Several Android settings were stored under keys the playback service never read, while lyric settings existed without being consumed by the renderer. Lyric focus also switched from the line timestamp instead of the first actual syllable. AutoMix used a fixed preload lead and lacked the upstream planner/configuration layer.

## Validation

- pure Kotlin compilation and behavior tests for AutoMix planning/envelopes and lyric pseudo timing
- settings preference compilation against Compose/runtime stubs
- `git diff --check`
- full Android debug build runs in GitHub Actions and uploads the APK artifact

## Known limitation

MeloX currently ships BeatNet as a CoreML model. This PR does not pretend that model can run directly on Android; Smart mode uses available analysis when supplied and otherwise follows the selected fallback. A TFLite/ONNX model and Android inference runtime remain separate migration work.
