### PR TITLE
feat: HyperOS Super Island lyrics + Lyricon provider

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:5.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("com.google.zxing:core:3.5.4")
+    implementation("com.xzakota.hyper.notification:focus-api:1.4")
 
     testImplementation("junit:junit:4.13.2")
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.lladlam.melox.android"
         minSdk = 26
         targetSdk = 37
-        versionCode = 3
-        versionName = "0.3.0-Dev"
+        versionCode = 4
+        versionName = "0.3.1-Dev"
     }
 
     buildFeatures {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("com.google.zxing:core:3.5.4")
     implementation("com.xzakota.hyper.notification:focus-api:1.4")
+    implementation("io.github.proify.lyricon:provider:0.1.70")
 
     testImplementation("junit:junit:4.13.2")
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,6 +47,11 @@
                 android:resource="@xml/melox_file_paths" />
         </provider>
 
+        <provider
+            android:name=".platform.xiaomi.MeloXHyperOsIslandInitializerProvider"
+            android:authorities="${applicationId}.hyperos-island-init"
+            android:exported="false" />
+
         <service
             android:name=".playback.MeloXPlaybackService"
             android:exported="true"
@@ -64,6 +69,15 @@
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Shows the currently playing lyric in a user-enabled overlay." />
+        </service>
+
+        <service
+            android:name=".platform.xiaomi.MeloXHyperOsIslandLyricService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Live lyric rendering for Xiaomi HyperOS Super Island." />
         </service>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,16 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.MeloX">
+
+        <meta-data android:name="lyricon_module" android:value="true" />
+        <meta-data android:name="lyricon_module_author" android:value="lladlam" />
+        <meta-data
+            android:name="lyricon_module_description"
+            android:value="MeloX rich lyric provider for Lyricon" />
+        <meta-data
+            android:name="lyricon_module_tags"
+            android:resource="@array/lyricon_module_tags" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
@@ -53,6 +63,11 @@
         <provider
             android:name=".platform.xiaomi.MeloXHyperOsIslandInitializerProvider"
             android:authorities="${applicationId}.hyperos-island-init"
+            android:exported="false" />
+
+        <provider
+            android:name=".platform.lyricon.MeloXLyriconInitializerProvider"
+            android:authorities="${applicationId}.lyricon-init"
             android:exported="false" />
 
         <service

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk tools:overrideLibrary="com.xzakota.hyper.notification.focus" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconInitializerProvider.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconInitializerProvider.kt
@@ -1,0 +1,33 @@
+package com.lladlam.melox.platform.lyricon
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+/** Starts the lightweight Lyricon Provider bridge with the MeloX application process. */
+class MeloXLyriconInitializerProvider : ContentProvider() {
+    override fun onCreate(): Boolean {
+        val app = context?.applicationContext ?: return false
+        MeloXLyriconRuntime.start(app)
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconRuntime.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconRuntime.kt
@@ -1,0 +1,292 @@
+package com.lladlam.melox.platform.lyricon
+
+import android.content.ComponentName
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.lladlam.melox.core.account.NeteaseSessionStore
+import com.lladlam.melox.core.download.MeloXDownloadStore
+import com.lladlam.melox.core.lyrics.LyricLine
+import com.lladlam.melox.core.lyrics.LyricsDocument
+import com.lladlam.melox.core.music.model.MusicAlbumRef
+import com.lladlam.melox.core.music.model.MusicArtistRef
+import com.lladlam.melox.core.music.model.MusicSource
+import com.lladlam.melox.core.music.model.MusicTrack
+import com.lladlam.melox.core.music.provider.LyricsCapability
+import com.lladlam.melox.core.music.provider.MeloXMusicProviders
+import com.lladlam.melox.core.network.NeteaseSearchClient
+import com.lladlam.melox.playback.MeloXPlaybackService
+import com.lladlam.melox.playback.PlaybackTrackIdentity
+import com.lladlam.melox.ui.settings.MeloXSettingsPreferences
+import io.github.proify.lyricon.lyric.model.LyricWord
+import io.github.proify.lyricon.lyric.model.RichLyricLine
+import io.github.proify.lyricon.lyric.model.Song
+import io.github.proify.lyricon.provider.LyriconFactory
+import io.github.proify.lyricon.provider.LyriconProvider
+import java.util.concurrent.Executor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Process-scoped Lyricon Provider integration.
+ *
+ * MeloX is a player, so it acts as a Lyricon Provider: current media metadata, real line/word
+ * timing, translation, romanization, playback state and position are pushed to Lyricon's
+ * central service. The Subscriber API is intentionally not used because it consumes another
+ * player's state instead of publishing MeloX's own state.
+ */
+internal object MeloXLyriconRuntime {
+    private const val TAG = "MeloXLyricon"
+    private const val UPDATE_INTERVAL_MS = 250L
+    private const val ORIGINAL_TITLE_KEY = "melox.system.original_title"
+    private const val ORIGINAL_ARTIST_KEY = "melox.system.original_artist"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val handler = Handler(Looper.getMainLooper())
+
+    private var appContext: Context? = null
+    private var controller: MediaController? = null
+    private var provider: LyriconProvider? = null
+    private var lyricJob: Job? = null
+    private var currentTrackKey: String? = null
+    private var lastPositionDispatchMs = 0L
+    private var lastPlaying: Boolean? = null
+    private var lastTranslation: Boolean? = null
+    private var lastRomanization: Boolean? = null
+    private var started = false
+
+    private var registry: com.lladlam.melox.core.music.provider.MusicProviderRegistry? = null
+    private var downloads: MeloXDownloadStore? = null
+
+    fun start(context: Context) {
+        if (started) return
+        val app = context.applicationContext
+        started = true
+        appContext = app
+        registry = MeloXMusicProviders.create(app)
+        downloads = MeloXDownloadStore.get(app)
+
+        provider = LyriconFactory.createProvider(
+            context = app,
+            providerPackageName = app.packageName,
+            playerPackageName = app.packageName,
+        ).apply {
+            autoSync = true
+            register()
+            player.setPositionUpdateInterval(UPDATE_INTERVAL_MS.toInt())
+        }
+
+        val token = SessionToken(app, ComponentName(app, MeloXPlaybackService::class.java))
+        val future = MediaController.Builder(app, token).buildAsync()
+        val executor = Executor { command -> app.mainExecutor.execute(command) }
+        future.addListener(
+            {
+                runCatching { future.get() }
+                    .onSuccess {
+                        controller = it
+                        handler.post(updater)
+                    }
+                    .onFailure { error ->
+                        Log.w(TAG, "Unable to connect to MeloX MediaSession", error)
+                    }
+            },
+            executor,
+        )
+    }
+
+    private val updater = object : Runnable {
+        override fun run() {
+            runCatching { publishCurrentState() }
+                .onFailure { Log.w(TAG, "Lyricon state update failed", it) }
+            if (started) handler.postDelayed(this, UPDATE_INTERVAL_MS)
+        }
+    }
+
+    private fun publishCurrentState() {
+        val remote = provider?.player ?: return
+        val active = controller ?: return
+        val item = active.currentMediaItem
+        if (item == null) {
+            if (currentTrackKey != null) {
+                currentTrackKey = null
+                remote.setSong(null)
+            }
+            return
+        }
+
+        val identity = PlaybackTrackIdentity.fromMediaItem(item) ?: return
+        val key = PlaybackTrackIdentity.encode(identity)
+        if (key != currentTrackKey) {
+            currentTrackKey = key
+            lyricJob?.cancel()
+            val metadata = stableMetadata(item.mediaMetadata)
+            remote.setSong(
+                Song(
+                    id = key,
+                    name = metadata.title?.toString(),
+                    artist = metadata.artist?.toString(),
+                    duration = active.duration.takeIf { it != C.TIME_UNSET && it > 0L } ?: 0L,
+                ),
+            )
+            lyricJob = scope.launch {
+                val document = withContext(Dispatchers.IO) {
+                    runCatching { loadLyrics(item, identity.source) }
+                        .onFailure { Log.w(TAG, "Unable to load lyrics for $key", it) }
+                        .getOrNull()
+                }
+                if (currentTrackKey == key && document != null) {
+                    val current = controller
+                    val stable = stableMetadata(item.mediaMetadata)
+                    remote.setSong(
+                        Song(
+                            id = key,
+                            name = stable.title?.toString(),
+                            artist = stable.artist?.toString(),
+                            duration = current?.duration?.takeIf { it != C.TIME_UNSET && it > 0L }
+                                ?: 0L,
+                            lyrics = document.toLyriconLines(),
+                        ),
+                    )
+                    current?.currentPosition?.coerceAtLeast(0L)?.let(remote::setPosition)
+                }
+                lyricJob = null
+            }
+        }
+
+        val playing = active.isPlaying
+        if (playing != lastPlaying) {
+            remote.setPlaybackState(playing)
+            lastPlaying = playing
+        }
+
+        val context = appContext ?: return
+        val translation = MeloXSettingsPreferences.boolean(context, "lyrics_translation", true)
+        if (translation != lastTranslation) {
+            remote.setDisplayTranslation(translation)
+            lastTranslation = translation
+        }
+        val romanization = MeloXSettingsPreferences.boolean(context, "lyrics_romanization", true)
+        if (romanization != lastRomanization) {
+            remote.setDisplayRoma(romanization)
+            lastRomanization = romanization
+        }
+
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastPositionDispatchMs >= UPDATE_INTERVAL_MS) {
+            remote.setPosition(active.currentPosition.coerceAtLeast(0L))
+            lastPositionDispatchMs = now
+        }
+    }
+
+    private suspend fun loadLyrics(item: MediaItem, source: MusicSource): LyricsDocument {
+        val context = appContext ?: return LyricsDocument(emptyList())
+        val identity = PlaybackTrackIdentity.fromMediaItem(item)
+            ?: return LyricsDocument(emptyList())
+        if (source == MusicSource.Netease) {
+            val songId = identity.value.toLongOrNull() ?: return LyricsDocument(emptyList())
+            return downloads?.localLyrics(songId)
+                ?: NeteaseSearchClient(
+                    cookieProvider = { NeteaseSessionStore.readCookie(context) },
+                ).lyrics(songId)
+        }
+
+        val capability = registry?.require(source) as? LyricsCapability
+            ?: return LyricsDocument(emptyList())
+        val metadata = stableMetadata(item.mediaMetadata)
+        val artistRefs = metadata.artist?.toString().orEmpty()
+            .split(Regex("\\s*(?:、|/|&|,|;|；)\\s*"))
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .ifEmpty { listOf("未知歌手") }
+            .map { MusicArtistRef(name = it) }
+        val albumName = metadata.albumTitle?.toString().orEmpty()
+        val track = MusicTrack(
+            id = identity,
+            title = metadata.title?.toString().orEmpty().ifBlank { "未知歌曲" },
+            artists = artistRefs,
+            album = albumName.takeIf(String::isNotBlank)?.let { name ->
+                MusicAlbumRef(name = name, artworkUrl = metadata.artworkUri?.toString())
+            },
+            artworkUrl = metadata.artworkUri?.toString(),
+            durationMs = controller?.duration?.takeIf { it != C.TIME_UNSET && it > 0L },
+        )
+        return capability.lyrics(track)
+    }
+
+    private fun stableMetadata(metadata: MediaMetadata): MediaMetadata {
+        val extras = metadata.extras
+        val originalTitle = extras?.getString(ORIGINAL_TITLE_KEY)
+        val originalArtist = extras?.getString(ORIGINAL_ARTIST_KEY)
+        if (originalTitle.isNullOrBlank() && originalArtist.isNullOrBlank()) return metadata
+        return metadata.buildUpon()
+            .setTitle(originalTitle?.takeIf(String::isNotBlank) ?: metadata.title)
+            .setArtist(originalArtist?.takeIf(String::isNotBlank) ?: metadata.artist)
+            .setAlbumTitle(originalArtist?.takeIf(String::isNotBlank) ?: metadata.albumTitle)
+            .build()
+    }
+
+    private fun LyricsDocument.toLyriconLines(): List<RichLyricLine> =
+        lines.mapIndexedNotNull { index, line -> line.toLyriconLine(lines.getOrNull(index + 1)) }
+
+    private fun LyricLine.toLyriconLine(next: LyricLine?): RichLyricLine? {
+        val beginMs = timeMs.coerceAtLeast(0L)
+        val inferredEnd = durationMs?.let { beginMs + it }
+            ?: next?.timeMs
+            ?: (beginMs + 3_000L)
+        val endMs = inferredEnd.coerceAtLeast(beginMs + 1L)
+        val primaryText = text.trim().takeIf(String::isNotBlank) ?: return null
+        val words = syllables
+            .mapNotNull { syllable ->
+                val wordText = syllable.text.takeIf(String::isNotEmpty) ?: return@mapNotNull null
+                val wordBegin = syllable.startTimeMs.coerceIn(beginMs, endMs - 1L)
+                val wordEnd = syllable.endTimeMs.coerceIn(wordBegin + 1L, endMs)
+                LyricWord(
+                    begin = wordBegin,
+                    end = wordEnd,
+                    text = wordText,
+                )
+            }
+            .takeIf(List<LyricWord>::isNotEmpty)
+        return RichLyricLine(
+            begin = beginMs,
+            end = endMs,
+            text = primaryText,
+            words = words,
+            translation = translation?.trim()?.takeIf(String::isNotBlank),
+            roma = romanization?.trim()?.takeIf(String::isNotBlank),
+        )
+    }
+
+    fun stop() {
+        if (!started) return
+        started = false
+        handler.removeCallbacks(updater)
+        lyricJob?.cancel()
+        lyricJob = null
+        runCatching { provider?.player?.setSong(null) }
+        runCatching { provider?.unregister() }
+        runCatching { provider?.destroy() }
+        provider = null
+        controller?.release()
+        controller = null
+        currentTrackKey = null
+        lastPlaying = null
+        lastTranslation = null
+        lastRomanization = null
+        registry = null
+        downloads = null
+        appContext = null
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconRuntime.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconRuntime.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -83,6 +82,8 @@ internal object MeloXLyriconRuntime {
             providerPackageName = app.packageName,
             playerPackageName = app.packageName,
         ).apply {
+            // The Lyricon 0.1.70 Provider docs recommend autoSync so the last cached
+            // song/player state is automatically restored after the central service reconnects.
             autoSync = true
             register()
             player.setPositionUpdateInterval(UPDATE_INTERVAL_MS.toInt())
@@ -96,6 +97,9 @@ internal object MeloXLyriconRuntime {
                 runCatching { future.get() }
                     .onSuccess {
                         controller = it
+                        // Publish immediately once Media3 is connected; the periodic loop then
+                        // keeps position/play state current without rebuilding lyrics every tick.
+                        publishCurrentState()
                         handler.post(updater)
                     }
                     .onFailure { error ->
@@ -159,7 +163,18 @@ internal object MeloXLyriconRuntime {
                             lyrics = document.toLyriconLines(),
                         ),
                     )
+                    // Follow the documented setSong -> setPosition -> playback/display-state order
+                    // so a reconnect or track switch cannot briefly render a stale timeline.
                     current?.currentPosition?.coerceAtLeast(0L)?.let(remote::setPosition)
+                    current?.let { remote.setPlaybackState(it.isPlaying) }
+                    appContext?.let { context ->
+                        remote.setDisplayTranslation(
+                            MeloXSettingsPreferences.boolean(context, "lyrics_translation", true),
+                        )
+                        remote.setDisplayRoma(
+                            MeloXSettingsPreferences.boolean(context, "lyrics_romanization", true),
+                        )
+                    }
                 }
                 lyricJob = null
             }
@@ -230,10 +245,11 @@ internal object MeloXLyriconRuntime {
         val originalTitle = extras?.getString(ORIGINAL_TITLE_KEY)
         val originalArtist = extras?.getString(ORIGINAL_ARTIST_KEY)
         if (originalTitle.isNullOrBlank() && originalArtist.isNullOrBlank()) return metadata
+        // System-lyric title hijacking stores the real title/artist in extras. Restore only those
+        // two fields: the album title is unrelated and must remain the original album metadata.
         return metadata.buildUpon()
             .setTitle(originalTitle?.takeIf(String::isNotBlank) ?: metadata.title)
             .setArtist(originalArtist?.takeIf(String::isNotBlank) ?: metadata.artist)
-            .setAlbumTitle(originalArtist?.takeIf(String::isNotBlank) ?: metadata.albumTitle)
             .build()
     }
 
@@ -285,6 +301,7 @@ internal object MeloXLyriconRuntime {
         lastPlaying = null
         lastTranslation = null
         lastRomanization = null
+        lastPositionDispatchMs = 0L
         registry = null
         downloads = null
         appContext = null

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -2,6 +2,7 @@ package com.lladlam.melox.platform.xiaomi
 
 import android.app.Notification
 import android.content.Context
+import android.os.Build
 import android.provider.Settings
 import org.json.JSONObject
 
@@ -32,7 +33,8 @@ object HyperOsFocusBridge {
     }
 
     fun supportsSuperIsland(context: Context): Boolean =
-        protocol(context) == Protocol.HyperOs3
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 &&
+            protocol(context) == Protocol.HyperOs3
 
     /**
      * Compatibility path for the existing generic lyrics notification on HyperOS 1/2.

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -1,20 +1,29 @@
 package com.lladlam.melox.platform.xiaomi
 
 import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.provider.Settings
-import org.json.JSONObject
+import com.xzakota.hyper.notification.focus.FocusNotification
+import com.xzakota.hyper.notification.island.model.TextInfo
 
 /**
- * Xiaomi HyperOS integration boundary.
+ * Xiaomi HyperOS Focus / Super Island integration boundary.
  *
- * Normal music playback should continue to use Android MediaSession/Media3.
- * This bridge is reserved for HyperOS focus notifications / Super Island
- * scenarios that do not map cleanly to the standard media notification.
+ * The Focus V3 notification shape is independently adapted for MeloX from the
+ * Apache-2.0 Halcyon implementation referenced during the HyperOS lyric port.
+ * Normal playback remains owned by Media3; this object only builds the vendor
+ * notification surface.
  */
 object HyperOsFocusBridge {
-    private const val FOCUS_PROTOCOL_SETTING = "notification_focus_protocol"
-    private const val FOCUS_PARAM_KEY = "miui.focus.param"
+    const val ChannelId = "melox_hyperos_super_island_lyrics_v1"
+    const val NotificationId = 0x4d584953
+    const val MinimumRenderIntervalMs = 1_500L
+
+    private const val FocusProtocolSetting = "notification_focus_protocol"
+    private const val DefaultAccent = 0xFF3482FF.toInt()
 
     enum class Protocol(val version: Int) {
         Unsupported(0),
@@ -25,7 +34,7 @@ object HyperOsFocusBridge {
 
     fun protocol(context: Context): Protocol {
         val version = runCatching {
-            Settings.System.getInt(context.contentResolver, FOCUS_PROTOCOL_SETTING, 0)
+            Settings.System.getInt(context.contentResolver, FocusProtocolSetting, 0)
         }.getOrDefault(0)
         return Protocol.entries.firstOrNull { it.version == version }
             ?: Protocol.Unsupported
@@ -34,41 +43,147 @@ object HyperOsFocusBridge {
     fun supportsSuperIsland(context: Context): Boolean =
         protocol(context) == Protocol.HyperOs3
 
-    fun playbackPayload(
+    fun ensureChannel(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(ChannelId) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                ChannelId,
+                "HyperOS 岛歌词",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "在 HyperOS 超级岛显示当前播放歌词"
+                setSound(null, null)
+                enableVibration(false)
+                setShowBadge(false)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            },
+        )
+    }
+
+    fun warmNotification(
         context: Context,
+        contentIntent: PendingIntent,
+    ): Notification {
+        ensureChannel(context)
+        return Notification.Builder(context, ChannelId)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle("MeloX 岛歌词")
+            .setContentText("等待播放歌词")
+            .setContentIntent(contentIntent)
+            .setOnlyAlertOnce(true)
+            .setOngoing(true)
+            .setLocalOnly(true)
+            .setShowWhen(false)
+            .setCategory(Notification.CATEGORY_TRANSPORT)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+            .build()
+    }
+
+    fun lyricNotification(
+        context: Context,
+        contentIntent: PendingIntent,
         lyric: String,
+        nextLine: String,
         songTitle: String,
         artist: String,
         positionMs: Long,
         durationMs: Long,
         isPlaying: Boolean,
-    ): String? {
-        val protocol = protocol(context)
-        if (protocol == Protocol.Unsupported) return null
-        return JSONObject().apply {
-            put("protocolVersion", protocol.version)
-            put("scene", "music")
-            put("source", "MeloX")
-            put("title", lyric)
-            put("song", songTitle)
-            put("artist", artist)
-            put("position", positionMs.coerceAtLeast(0L))
-            put("duration", durationMs.coerceAtLeast(0L))
-            put("playing", isPlaying)
-            if (protocol == Protocol.HyperOs3) put("superIsland", true)
-        }.toString()
-    }
+    ): Notification? {
+        if (!supportsSuperIsland(context)) return null
+        ensureChannel(context)
 
-    /**
-     * Attaches Xiaomi's documented focus-notification payload to an already
-     * built Android notification. Callers remain responsible for Xiaomi's
-     * scene approval/permission requirements and for providing a valid JSON
-     * payload for the target HyperOS protocol.
-     */
-    fun attachFocusParams(
-        notification: Notification,
-        islandParamsJson: String,
-    ): Notification = notification.apply {
-        extras.putString(FOCUS_PARAM_KEY, islandParamsJson)
+        val fullLyric = lyric.trim().ifBlank { "♪" }
+        val trackLabel = listOf(songTitle.trim(), artist.trim())
+            .filter(String::isNotBlank)
+            .joinToString(" - ")
+            .ifBlank { "MeloX" }
+        val progress = if (durationMs > 0L) {
+            ((positionMs.coerceIn(0L, durationMs) * 100L) / durationMs)
+                .toInt()
+                .coerceIn(0, 100)
+        } else {
+            0
+        }
+        val split = XiaomiSuperIslandLyricLayout.splitFullLyric(fullLyric)
+        val accent = String.format("#FF%06X", DefaultAccent and 0xFFFFFF)
+
+        val extras = FocusNotification.buildV3 {
+            business = "lyric_display"
+            isShowNotification = true
+            enableFloat = false
+            updatable = true
+            islandFirstFloat = false
+            aodTitle = fullLyric.take(20)
+            ticker = fullLyric
+
+            chatInfo {
+                title = fullLyric
+                content = trackLabel
+                appIconPkg = context.packageName
+            }
+
+            progressInfo {
+                this.progress = progress
+                colorProgress = accent
+                colorProgressEnd = accent
+            }
+
+            island {
+                islandProperty = 1
+                highlightColor = accent
+                bigIslandArea {
+                    imageTextInfoLeft {
+                        type = 1
+                        textInfo {
+                            title = split.left.ifBlank { trackLabel }
+                            showHighlightColor = false
+                            narrowFont = false
+                        }
+                    }
+                    textInfo = TextInfo().apply {
+                        title = split.right.ifBlank { fullLyric }
+                        showHighlightColor = true
+                        narrowFont = false
+                    }
+                }
+                shareData {
+                    title = songTitle.ifBlank { "MeloX" }
+                    content = artist.ifBlank { nextLine.ifBlank { fullLyric } }
+                    shareContent = buildString {
+                        append(fullLyric)
+                        if (songTitle.isNotBlank()) append('\n').append(songTitle)
+                        if (artist.isNotBlank()) append(" - ").append(artist)
+                    }
+                }
+                smallIslandArea {
+                    combinePicInfo {
+                        progressInfo {
+                            this.progress = progress
+                            colorReach = accent
+                            colorUnReach = "#333333"
+                        }
+                    }
+                }
+            }
+        }
+
+        return Notification.Builder(context, ChannelId)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle(fullLyric)
+            .setContentText(trackLabel)
+            .setSubText(context.packageName)
+            .setContentIntent(contentIntent)
+            .setOnlyAlertOnce(true)
+            .setOngoing(isPlaying)
+            .setAutoCancel(false)
+            .setLocalOnly(true)
+            .setShowWhen(false)
+            .setCategory(Notification.CATEGORY_TRANSPORT)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+            .setColor(DefaultAccent)
+            .addExtras(extras)
+            .build()
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.provider.Settings
 import com.xzakota.hyper.notification.focus.FocusNotification
 import com.xzakota.hyper.notification.island.model.TextInfo
+import org.json.JSONObject
 
 /**
  * Xiaomi HyperOS Focus / Super Island integration boundary.
@@ -23,6 +24,7 @@ object HyperOsFocusBridge {
     const val MinimumRenderIntervalMs = 1_500L
 
     private const val FocusProtocolSetting = "notification_focus_protocol"
+    private const val LegacyFocusParamKey = "miui.focus.param"
     private const val DefaultAccent = 0xFF3482FF.toInt()
 
     enum class Protocol(val version: Int) {
@@ -42,6 +44,42 @@ object HyperOsFocusBridge {
 
     fun supportsSuperIsland(context: Context): Boolean =
         protocol(context) == Protocol.HyperOs3
+
+    /**
+     * Compatibility path for the existing generic lyrics notification on HyperOS 1/2.
+     * HyperOS 3 returns null here because the dedicated Focus V3 foreground service owns
+     * Super Island updates and must not be duplicated by the old ad-hoc payload.
+     */
+    fun playbackPayload(
+        context: Context,
+        lyric: String,
+        songTitle: String,
+        artist: String,
+        positionMs: Long,
+        durationMs: Long,
+        isPlaying: Boolean,
+    ): String? {
+        val protocol = protocol(context)
+        if (protocol == Protocol.Unsupported || protocol == Protocol.HyperOs3) return null
+        return JSONObject().apply {
+            put("protocolVersion", protocol.version)
+            put("scene", "music")
+            put("source", "MeloX")
+            put("title", lyric)
+            put("song", songTitle)
+            put("artist", artist)
+            put("position", positionMs.coerceAtLeast(0L))
+            put("duration", durationMs.coerceAtLeast(0L))
+            put("playing", isPlaying)
+        }.toString()
+    }
+
+    fun attachFocusParams(
+        notification: Notification,
+        islandParamsJson: String,
+    ): Notification = notification.apply {
+        extras.putString(LegacyFocusParamKey, islandParamsJson)
+    }
 
     fun ensureChannel(context: Context) {
         val manager = context.getSystemService(NotificationManager::class.java)

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -1,31 +1,20 @@
 package com.lladlam.melox.platform.xiaomi
 
 import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
 import android.provider.Settings
-import com.xzakota.hyper.notification.focus.FocusNotification
-import com.xzakota.hyper.notification.island.model.TextInfo
 import org.json.JSONObject
 
 /**
- * Xiaomi HyperOS Focus / Super Island integration boundary.
+ * Lightweight Xiaomi integration boundary loaded by MeloX's ordinary playback service.
  *
- * The Focus V3 notification shape is independently adapted for MeloX from the
- * Apache-2.0 Halcyon implementation referenced during the HyperOS lyric port.
- * Normal playback remains owned by Media3; this object only builds the vendor
- * notification surface.
+ * This class intentionally contains no focus-api references. HyperOS 3 Focus V3 creation is
+ * isolated in [HyperOsFocusV3NotificationFactory], which is only entered after protocol 3 is
+ * detected. That keeps MeloX's existing API 26 compatibility path independent of the vendor SDK.
  */
 object HyperOsFocusBridge {
-    const val ChannelId = "melox_hyperos_super_island_lyrics_v1"
-    const val NotificationId = 0x4d584953
-    const val MinimumRenderIntervalMs = 1_500L
-
     private const val FocusProtocolSetting = "notification_focus_protocol"
     private const val LegacyFocusParamKey = "miui.focus.param"
-    private const val DefaultAccent = 0xFF3482FF.toInt()
 
     enum class Protocol(val version: Int) {
         Unsupported(0),
@@ -47,8 +36,7 @@ object HyperOsFocusBridge {
 
     /**
      * Compatibility path for the existing generic lyrics notification on HyperOS 1/2.
-     * HyperOS 3 returns null here because the dedicated Focus V3 foreground service owns
-     * Super Island updates and must not be duplicated by the old ad-hoc payload.
+     * HyperOS 3 returns null because its dedicated Focus V3 foreground service owns the island.
      */
     fun playbackPayload(
         context: Context,
@@ -79,149 +67,5 @@ object HyperOsFocusBridge {
         islandParamsJson: String,
     ): Notification = notification.apply {
         extras.putString(LegacyFocusParamKey, islandParamsJson)
-    }
-
-    fun ensureChannel(context: Context) {
-        val manager = context.getSystemService(NotificationManager::class.java)
-        if (manager.getNotificationChannel(ChannelId) != null) return
-        manager.createNotificationChannel(
-            NotificationChannel(
-                ChannelId,
-                "HyperOS 岛歌词",
-                NotificationManager.IMPORTANCE_HIGH,
-            ).apply {
-                description = "在 HyperOS 超级岛显示当前播放歌词"
-                setSound(null, null)
-                enableVibration(false)
-                setShowBadge(false)
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-            },
-        )
-    }
-
-    fun warmNotification(
-        context: Context,
-        contentIntent: PendingIntent,
-    ): Notification {
-        ensureChannel(context)
-        return Notification.Builder(context, ChannelId)
-            .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle("MeloX 岛歌词")
-            .setContentText("等待播放歌词")
-            .setContentIntent(contentIntent)
-            .setOnlyAlertOnce(true)
-            .setOngoing(true)
-            .setLocalOnly(true)
-            .setShowWhen(false)
-            .setCategory(Notification.CATEGORY_TRANSPORT)
-            .setVisibility(Notification.VISIBILITY_PUBLIC)
-            .build()
-    }
-
-    fun lyricNotification(
-        context: Context,
-        contentIntent: PendingIntent,
-        lyric: String,
-        nextLine: String,
-        songTitle: String,
-        artist: String,
-        positionMs: Long,
-        durationMs: Long,
-        isPlaying: Boolean,
-    ): Notification? {
-        if (!supportsSuperIsland(context)) return null
-        ensureChannel(context)
-
-        val fullLyric = lyric.trim().ifBlank { "♪" }
-        val trackLabel = listOf(songTitle.trim(), artist.trim())
-            .filter(String::isNotBlank)
-            .joinToString(" - ")
-            .ifBlank { "MeloX" }
-        val progress = if (durationMs > 0L) {
-            ((positionMs.coerceIn(0L, durationMs) * 100L) / durationMs)
-                .toInt()
-                .coerceIn(0, 100)
-        } else {
-            0
-        }
-        val split = XiaomiSuperIslandLyricLayout.splitFullLyric(fullLyric)
-        val accent = String.format("#FF%06X", DefaultAccent and 0xFFFFFF)
-
-        val extras = FocusNotification.buildV3 {
-            business = "lyric_display"
-            isShowNotification = true
-            enableFloat = false
-            updatable = true
-            islandFirstFloat = false
-            aodTitle = fullLyric.take(20)
-            ticker = fullLyric
-
-            chatInfo {
-                title = fullLyric
-                content = trackLabel
-                appIconPkg = context.packageName
-            }
-
-            progressInfo {
-                this.progress = progress
-                colorProgress = accent
-                colorProgressEnd = accent
-            }
-
-            island {
-                islandProperty = 1
-                highlightColor = accent
-                bigIslandArea {
-                    imageTextInfoLeft {
-                        type = 1
-                        textInfo {
-                            title = split.left.ifBlank { trackLabel }
-                            showHighlightColor = false
-                            narrowFont = false
-                        }
-                    }
-                    textInfo = TextInfo().apply {
-                        title = split.right.ifBlank { fullLyric }
-                        showHighlightColor = true
-                        narrowFont = false
-                    }
-                }
-                shareData {
-                    title = songTitle.ifBlank { "MeloX" }
-                    content = artist.ifBlank { nextLine.ifBlank { fullLyric } }
-                    shareContent = buildString {
-                        append(fullLyric)
-                        if (songTitle.isNotBlank()) append('\n').append(songTitle)
-                        if (artist.isNotBlank()) append(" - ").append(artist)
-                    }
-                }
-                smallIslandArea {
-                    combinePicInfo {
-                        progressInfo {
-                            this.progress = progress
-                            colorReach = accent
-                            colorUnReach = "#333333"
-                        }
-                    }
-                }
-            }
-        }
-
-        return Notification.Builder(context, ChannelId)
-            .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle(fullLyric)
-            .setContentText(trackLabel)
-            .setSubText(context.packageName)
-            .setContentIntent(contentIntent)
-            .setOnlyAlertOnce(true)
-            .setOngoing(isPlaying)
-            .setAutoCancel(false)
-            .setLocalOnly(true)
-            .setShowWhen(false)
-            .setCategory(Notification.CATEGORY_TRANSPORT)
-            .setVisibility(Notification.VISIBILITY_PUBLIC)
-            .setColor(DefaultAccent)
-            .addExtras(extras)
-            .build()
     }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusV3NotificationFactory.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusV3NotificationFactory.kt
@@ -1,0 +1,167 @@
+package com.lladlam.melox.platform.xiaomi
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import com.xzakota.hyper.notification.focus.FocusNotification
+import com.xzakota.hyper.notification.island.model.TextInfo
+
+/**
+ * HyperOS 3-only Focus V3 notification factory.
+ *
+ * Every focus-api reference lives behind this class so API 26 / non-HyperOS devices can load
+ * MeloX playback without resolving a library whose published manifest declares minSdk 27.
+ * Callers must verify [HyperOsFocusBridge.supportsSuperIsland] before entering this factory.
+ */
+internal object HyperOsFocusV3NotificationFactory {
+    const val ChannelId = "melox_hyperos_super_island_lyrics_v1"
+    const val NotificationId = 0x4d584953
+    const val MinimumRenderIntervalMs = 1_500L
+
+    private const val DefaultAccent = 0xFF3482FF.toInt()
+
+    fun ensureChannel(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(ChannelId) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                ChannelId,
+                "HyperOS 岛歌词",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "在 HyperOS 超级岛显示当前播放歌词"
+                setSound(null, null)
+                enableVibration(false)
+                setShowBadge(false)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            },
+        )
+    }
+
+    fun warmNotification(
+        context: Context,
+        contentIntent: PendingIntent,
+    ): Notification {
+        ensureChannel(context)
+        return Notification.Builder(context, ChannelId)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle("MeloX 岛歌词")
+            .setContentText("等待播放歌词")
+            .setContentIntent(contentIntent)
+            .setOnlyAlertOnce(true)
+            .setOngoing(true)
+            .setLocalOnly(true)
+            .setShowWhen(false)
+            .setCategory(Notification.CATEGORY_TRANSPORT)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+            .build()
+    }
+
+    fun lyricNotification(
+        context: Context,
+        contentIntent: PendingIntent,
+        lyric: String,
+        nextLine: String,
+        songTitle: String,
+        artist: String,
+        positionMs: Long,
+        durationMs: Long,
+        isPlaying: Boolean,
+    ): Notification {
+        ensureChannel(context)
+
+        val fullLyric = lyric.trim().ifBlank { "♪" }
+        val trackLabel = listOf(songTitle.trim(), artist.trim())
+            .filter(String::isNotBlank)
+            .joinToString(" - ")
+            .ifBlank { "MeloX" }
+        val progress = if (durationMs > 0L) {
+            ((positionMs.coerceIn(0L, durationMs) * 100L) / durationMs)
+                .toInt()
+                .coerceIn(0, 100)
+        } else {
+            0
+        }
+        val split = XiaomiSuperIslandLyricLayout.splitFullLyric(fullLyric)
+        val accent = String.format("#FF%06X", DefaultAccent and 0xFFFFFF)
+
+        val extras = FocusNotification.buildV3 {
+            business = "lyric_display"
+            isShowNotification = true
+            enableFloat = false
+            updatable = true
+            islandFirstFloat = false
+            aodTitle = fullLyric.take(20)
+            ticker = fullLyric
+
+            chatInfo {
+                title = fullLyric
+                content = trackLabel
+                appIconPkg = context.packageName
+            }
+
+            progressInfo {
+                this.progress = progress
+                colorProgress = accent
+                colorProgressEnd = accent
+            }
+
+            island {
+                islandProperty = 1
+                highlightColor = accent
+                bigIslandArea {
+                    imageTextInfoLeft {
+                        type = 1
+                        textInfo {
+                            title = split.left.ifBlank { trackLabel }
+                            showHighlightColor = false
+                            narrowFont = false
+                        }
+                    }
+                    textInfo = TextInfo().apply {
+                        title = split.right.ifBlank { fullLyric }
+                        showHighlightColor = true
+                        narrowFont = false
+                    }
+                }
+                shareData {
+                    title = songTitle.ifBlank { "MeloX" }
+                    content = artist.ifBlank { nextLine.ifBlank { fullLyric } }
+                    shareContent = buildString {
+                        append(fullLyric)
+                        if (songTitle.isNotBlank()) append('\n').append(songTitle)
+                        if (artist.isNotBlank()) append(" - ").append(artist)
+                    }
+                }
+                smallIslandArea {
+                    combinePicInfo {
+                        progressInfo {
+                            this.progress = progress
+                            colorReach = accent
+                            colorUnReach = "#333333"
+                        }
+                    }
+                }
+            }
+        }
+
+        return Notification.Builder(context, ChannelId)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle(fullLyric)
+            .setContentText(trackLabel)
+            .setSubText(context.packageName)
+            .setContentIntent(contentIntent)
+            .setOnlyAlertOnce(true)
+            .setOngoing(isPlaying)
+            .setAutoCancel(false)
+            .setLocalOnly(true)
+            .setShowWhen(false)
+            .setCategory(Notification.CATEGORY_TRANSPORT)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+            .setColor(DefaultAccent)
+            .addExtras(extras)
+            .build()
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/MeloXHyperOsIslandInitializerProvider.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/MeloXHyperOsIslandInitializerProvider.kt
@@ -1,0 +1,73 @@
+package com.lladlam.melox.platform.xiaomi
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.database.Cursor
+import android.net.Uri
+import androidx.core.content.ContextCompat
+
+/**
+ * Process initializer that keeps the HyperOS island service aligned with the existing
+ * "歌词通知" preference without adding Xiaomi-specific logic to the canonical Settings UI.
+ */
+class MeloXHyperOsIslandInitializerProvider : ContentProvider(),
+    SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private var preferences: SharedPreferences? = null
+
+    override fun onCreate(): Boolean {
+        val app = context?.applicationContext ?: return false
+        preferences = app.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE).also {
+            it.registerOnSharedPreferenceChangeListener(this)
+        }
+        refresh(app)
+        return true
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
+        if (key != MeloXHyperOsIslandLyricService.PREFERENCE_KEY) return
+        context?.applicationContext?.let(::refresh)
+    }
+
+    private fun refresh(app: Context) {
+        val enabled = preferences?.getBoolean(
+            MeloXHyperOsIslandLyricService.PREFERENCE_KEY,
+            false,
+        ) == true
+        if (enabled && HyperOsFocusBridge.supportsSuperIsland(app)) {
+            runCatching {
+                ContextCompat.startForegroundService(
+                    app,
+                    Intent(app, MeloXHyperOsIslandLyricService::class.java),
+                )
+            }
+        } else {
+            app.stopService(Intent(app, MeloXHyperOsIslandLyricService::class.java))
+        }
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    companion object {
+        private const val PREFERENCES_NAME = "melox_app_settings"
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/MeloXHyperOsIslandLyricService.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/MeloXHyperOsIslandLyricService.kt
@@ -1,0 +1,248 @@
+package com.lladlam.melox.platform.xiaomi
+
+import android.app.PendingIntent
+import android.app.Service
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.lladlam.melox.MainActivity
+import com.lladlam.melox.core.account.NeteaseSessionStore
+import com.lladlam.melox.core.download.MeloXDownloadStore
+import com.lladlam.melox.core.lyrics.LyricsDocument
+import com.lladlam.melox.core.music.model.MusicAlbumRef
+import com.lladlam.melox.core.music.model.MusicArtistRef
+import com.lladlam.melox.core.music.model.MusicSource
+import com.lladlam.melox.core.music.model.MusicTrack
+import com.lladlam.melox.core.music.provider.LyricsCapability
+import com.lladlam.melox.core.music.provider.MeloXMusicProviders
+import com.lladlam.melox.core.network.NeteaseSearchClient
+import com.lladlam.melox.playback.MeloXPlaybackService
+import com.lladlam.melox.playback.PlaybackTrackIdentity
+import com.lladlam.melox.ui.settings.MeloXSettingsPreferences
+import java.util.concurrent.Executor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Dedicated foreground owner for HyperOS Focus V3 lyric notifications.
+ *
+ * Keeping the Focus notification separate from Media3's standard media notification mirrors
+ * the lifecycle HyperOS expects and avoids coupling Xiaomi-only payload updates to playback.
+ */
+class MeloXHyperOsIslandLyricService : Service() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val handler = Handler(Looper.getMainLooper())
+    private var controller: MediaController? = null
+    private var lyricsJob: Job? = null
+    private var lyricKey: String? = null
+    private var lyrics: LyricsDocument? = null
+    private var lastPublishedIndex = Int.MIN_VALUE
+    private var lastPublishedAt = 0L
+    private var startedForeground = false
+
+    private val providerRegistry by lazy { MeloXMusicProviders.create(applicationContext) }
+    private val downloads by lazy { MeloXDownloadStore.get(applicationContext) }
+
+    private val contentIntent by lazy {
+        PendingIntent.getActivity(
+            this,
+            0x4d58,
+            Intent(this, MainActivity::class.java).apply {
+                action = MainActivity.ACTION_OPEN_NOW_PLAYING
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private val updater = object : Runnable {
+        override fun run() {
+            runCatching { updateIsland() }
+                .onFailure { Log.w(TAG, "HyperOS island lyric update failed", it) }
+            handler.postDelayed(this, UPDATE_INTERVAL_MS)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        if (!HyperOsFocusBridge.supportsSuperIsland(this)) {
+            stopSelf()
+            return
+        }
+        startAsForeground(HyperOsFocusBridge.warmNotification(this, contentIntent))
+        connectController()
+        handler.post(updater)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!isEnabled() || !HyperOsFocusBridge.supportsSuperIsland(this)) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        if (!startedForeground) {
+            startAsForeground(HyperOsFocusBridge.warmNotification(this, contentIntent))
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun connectController() {
+        val token = SessionToken(this, ComponentName(this, MeloXPlaybackService::class.java))
+        val future = MediaController.Builder(this, token).buildAsync()
+        val executor = Executor { command -> mainExecutor.execute(command) }
+        future.addListener(
+            {
+                runCatching { future.get() }
+                    .onSuccess { controller = it }
+                    .onFailure { Log.w(TAG, "Unable to connect HyperOS lyric controller", it) }
+            },
+            executor,
+        )
+    }
+
+    private fun updateIsland() {
+        if (!isEnabled()) {
+            stopSelf()
+            return
+        }
+        val active = controller ?: return
+        val item = active.currentMediaItem ?: return
+        val identity = PlaybackTrackIdentity.fromMediaItem(item) ?: return
+        val key = "${identity.source.storageValue}:${identity.value}"
+        if (key != lyricKey) requestLyrics(item, key)
+
+        val document = lyrics ?: return
+        val advance = MeloXSettingsPreferences.int(this, "lyrics_advance_ms", 0)
+        val position = (active.currentPosition + advance).coerceAtLeast(0L)
+        val index = document.highlightedIndex(position) ?: return
+        if (index !in document.lines.indices) return
+
+        val now = SystemClock.elapsedRealtime()
+        if (index == lastPublishedIndex) return
+        if (lastPublishedIndex != Int.MIN_VALUE &&
+            now - lastPublishedAt < HyperOsFocusBridge.MinimumRenderIntervalMs
+        ) return
+
+        val line = document.lines[index].text.trim().ifBlank { return }
+        val next = document.lines.getOrNull(index + 1)?.text.orEmpty()
+        val metadata = item.mediaMetadata
+        val duration = active.duration.takeIf { it != C.TIME_UNSET && it > 0L } ?: 0L
+        val notification = HyperOsFocusBridge.lyricNotification(
+            context = this,
+            contentIntent = contentIntent,
+            lyric = line,
+            nextLine = next,
+            songTitle = metadata.title?.toString().orEmpty(),
+            artist = metadata.artist?.toString().orEmpty(),
+            positionMs = active.currentPosition,
+            durationMs = duration,
+            isPlaying = active.isPlaying,
+        ) ?: return
+
+        startAsForeground(notification)
+        lastPublishedIndex = index
+        lastPublishedAt = now
+    }
+
+    private fun requestLyrics(item: MediaItem, key: String) {
+        lyricKey = key
+        lyrics = null
+        lastPublishedIndex = Int.MIN_VALUE
+        lastPublishedAt = 0L
+        lyricsJob?.cancel()
+        lyricsJob = scope.launch {
+            val loaded = withContext(Dispatchers.IO) {
+                runCatching { loadLyrics(item) }
+                    .onFailure { Log.w(TAG, "Unable to load HyperOS island lyrics for $key", it) }
+                    .getOrNull()
+            }
+            if (lyricKey == key) lyrics = loaded
+            lyricsJob = null
+        }
+    }
+
+    private suspend fun loadLyrics(item: MediaItem): LyricsDocument {
+        val identity = PlaybackTrackIdentity.fromMediaItem(item)
+            ?: return LyricsDocument(emptyList())
+        if (identity.source == MusicSource.Netease) {
+            val songId = identity.value.toLongOrNull() ?: return LyricsDocument(emptyList())
+            return downloads.localLyrics(songId)
+                ?: NeteaseSearchClient(
+                    cookieProvider = { NeteaseSessionStore.readCookie(applicationContext) },
+                ).lyrics(songId)
+        }
+
+        val capability = providerRegistry.require(identity.source) as? LyricsCapability
+            ?: return LyricsDocument(emptyList())
+        val metadata = item.mediaMetadata
+        val artists = metadata.artist?.toString().orEmpty()
+            .split(Regex("\\s*(?:、|/|&|,|;|；)\\s*"))
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .ifEmpty { listOf("未知歌手") }
+            .map { MusicArtistRef(name = it) }
+        val albumName = metadata.albumTitle?.toString().orEmpty()
+        val track = MusicTrack(
+            id = identity,
+            title = metadata.title?.toString().orEmpty().ifBlank { "未知歌曲" },
+            artists = artists,
+            album = albumName.takeIf(String::isNotBlank)?.let { name ->
+                MusicAlbumRef(
+                    name = name,
+                    artworkUrl = metadata.artworkUri?.toString(),
+                )
+            },
+            artworkUrl = metadata.artworkUri?.toString(),
+            durationMs = controller?.duration?.takeIf { it != C.TIME_UNSET && it > 0L },
+        )
+        return capability.lyrics(track)
+    }
+
+    private fun isEnabled(): Boolean =
+        MeloXSettingsPreferences.boolean(this, PREFERENCE_KEY, false)
+
+    private fun startAsForeground(notification: android.app.Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(
+                HyperOsFocusBridge.NotificationId,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+            )
+        } else {
+            startForeground(HyperOsFocusBridge.NotificationId, notification)
+        }
+        startedForeground = true
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(updater)
+        lyricsJob?.cancel()
+        controller?.release()
+        controller = null
+        scope.cancel()
+        runCatching { stopForeground(STOP_FOREGROUND_REMOVE) }
+        super.onDestroy()
+    }
+
+    companion object {
+        const val PREFERENCE_KEY = "lyrics_notifications_enabled"
+        private const val UPDATE_INTERVAL_MS = 250L
+        private const val TAG = "MeloXHyperOsIsland"
+    }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/MeloXHyperOsIslandLyricService.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/MeloXHyperOsIslandLyricService.kt
@@ -84,7 +84,7 @@ class MeloXHyperOsIslandLyricService : Service() {
             stopSelf()
             return
         }
-        startAsForeground(HyperOsFocusBridge.warmNotification(this, contentIntent))
+        startAsForeground(HyperOsFocusV3NotificationFactory.warmNotification(this, contentIntent))
         connectController()
         handler.post(updater)
     }
@@ -95,7 +95,7 @@ class MeloXHyperOsIslandLyricService : Service() {
             return START_NOT_STICKY
         }
         if (!startedForeground) {
-            startAsForeground(HyperOsFocusBridge.warmNotification(this, contentIntent))
+            startAsForeground(HyperOsFocusV3NotificationFactory.warmNotification(this, contentIntent))
         }
         return START_STICKY
     }
@@ -136,14 +136,14 @@ class MeloXHyperOsIslandLyricService : Service() {
         val now = SystemClock.elapsedRealtime()
         if (index == lastPublishedIndex) return
         if (lastPublishedIndex != Int.MIN_VALUE &&
-            now - lastPublishedAt < HyperOsFocusBridge.MinimumRenderIntervalMs
+            now - lastPublishedAt < HyperOsFocusV3NotificationFactory.MinimumRenderIntervalMs
         ) return
 
         val line = document.lines[index].text.trim().ifBlank { return }
         val next = document.lines.getOrNull(index + 1)?.text.orEmpty()
         val metadata = item.mediaMetadata
         val duration = active.duration.takeIf { it != C.TIME_UNSET && it > 0L } ?: 0L
-        val notification = HyperOsFocusBridge.lyricNotification(
+        val notification = HyperOsFocusV3NotificationFactory.lyricNotification(
             context = this,
             contentIntent = contentIntent,
             lyric = line,
@@ -153,7 +153,7 @@ class MeloXHyperOsIslandLyricService : Service() {
             positionMs = active.currentPosition,
             durationMs = duration,
             isPlaying = active.isPlaying,
-        ) ?: return
+        )
 
         startAsForeground(notification)
         lastPublishedIndex = index
@@ -220,12 +220,12 @@ class MeloXHyperOsIslandLyricService : Service() {
     private fun startAsForeground(notification: android.app.Notification) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startForeground(
-                HyperOsFocusBridge.NotificationId,
+                HyperOsFocusV3NotificationFactory.NotificationId,
                 notification,
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
             )
         } else {
-            startForeground(HyperOsFocusBridge.NotificationId, notification)
+            startForeground(HyperOsFocusV3NotificationFactory.NotificationId, notification)
         }
         startedForeground = true
     }

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/XiaomiSuperIslandLyricLayout.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/XiaomiSuperIslandLyricLayout.kt
@@ -1,0 +1,50 @@
+package com.lladlam.melox.platform.xiaomi
+
+/**
+ * Fits lyrics into HyperOS Super Island text slots using approximate visual width.
+ * CJK/kana/hangul glyphs consume roughly twice the width of latin glyphs.
+ *
+ * Layout strategy adapted for MeloX from Halcyon's Apache-2.0 Super Island implementation.
+ */
+internal object XiaomiSuperIslandLyricLayout {
+    data class Split(val left: String, val right: String)
+
+    fun visualWeight(text: String): Int = text.sumOf(::charWeight)
+
+    fun weightForCharacters(characters: Int): Int = characters.coerceAtLeast(1) * 2
+
+    fun takeByWeight(text: String, maxWeight: Int): String {
+        if (text.isBlank() || maxWeight <= 0) return ""
+        var weight = 0
+        val out = StringBuilder()
+        for (char in text.trim()) {
+            val next = charWeight(char)
+            if (out.isNotEmpty() && weight + next > maxWeight) break
+            out.append(char)
+            weight += next
+        }
+        return out.toString().trim()
+    }
+
+    fun splitFullLyric(
+        text: String,
+        leftMaxWeight: Int = weightForCharacters(11),
+        rightMaxWeight: Int = weightForCharacters(16),
+    ): Split {
+        val normalized = text.trim().replace(Regex("\\s+"), " ")
+        if (normalized.isBlank()) return Split("♪", "")
+        val left = takeByWeight(normalized, leftMaxWeight)
+        val remaining = normalized.removePrefix(left).trimStart()
+        val right = takeByWeight(remaining, rightMaxWeight)
+        return Split(left.ifBlank { "♪" }, right)
+    }
+
+    private fun charWeight(char: Char): Int = when {
+        char.isWhitespace() -> 0
+        char.code in 0x2E80..0x9FFF -> 2
+        char.code in 0x3040..0x30FF -> 2
+        char.code in 0xAC00..0xD7AF -> 2
+        char.code in 0xF900..0xFAFF -> 2
+        else -> 1
+    }
+}

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="lyricon_module_tags">
+        <item>$syllable</item>
+        <item>$translation</item>
+    </string-array>
+</resources>

--- a/android/app/src/test/kotlin/com/lladlam/melox/platform/xiaomi/XiaomiSuperIslandLyricLayoutTest.kt
+++ b/android/app/src/test/kotlin/com/lladlam/melox/platform/xiaomi/XiaomiSuperIslandLyricLayoutTest.kt
@@ -1,0 +1,35 @@
+package com.lladlam.melox.platform.xiaomi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XiaomiSuperIslandLyricLayoutTest {
+    @Test
+    fun cjkCharactersUseDoubleVisualWeight() {
+        assertEquals(4, XiaomiSuperIslandLyricLayout.visualWeight("歌词"))
+        assertEquals(3, XiaomiSuperIslandLyricLayout.visualWeight("abc"))
+    }
+
+    @Test
+    fun splitFullLyricPreservesOrderWithoutOverflow() {
+        val source = "愿所有的心声都在旋律里靠岸 tonight"
+        val split = XiaomiSuperIslandLyricLayout.splitFullLyric(
+            text = source,
+            leftMaxWeight = 12,
+            rightMaxWeight = 18,
+        )
+        assertTrue(split.left.isNotBlank())
+        assertTrue(XiaomiSuperIslandLyricLayout.visualWeight(split.left) <= 12)
+        assertTrue(XiaomiSuperIslandLyricLayout.visualWeight(split.right) <= 18)
+        assertTrue(source.startsWith(split.left))
+    }
+
+    @Test
+    fun emptyLyricFallsBackToMusicNote() {
+        assertEquals(
+            XiaomiSuperIslandLyricLayout.Split("♪", ""),
+            XiaomiSuperIslandLyricLayout.splitFullLyric("   "),
+        )
+    }
+}


### PR DESCRIPTION
## 0.3.1-Dev：HyperOS 岛歌词 + Lyricon / 词幕适配

本 PR 将 MeloX 的系统歌词输出扩展到 HyperOS 3 超级岛，并按照 Lyricon 当前 Provider / Subscriber 官方文档接入词幕。

### HyperOS 3 超级岛歌词
- 使用 `com.xzakota.hyper.notification:focus-api:1.4` 构造真实 Focus V3 payload，不再把自定义 JSON 当作 HyperOS 3 岛协议
- `notification_focus_protocol=3` 时启用 Super Island；HyperOS 1/2 保留旧普通 Focus 兼容路径
- Focus SDK 单独隔离在 HyperOS 3 factory，并额外要求 Android >= 8.1；MeloX `minSdk 26` 不变
- 独立 `specialUse` 前台服务持有岛歌词通知
- 复用原 MeloX “歌词通知”全局设置；设置变化会即时启动/停止岛歌词服务，不新增第二套小米设置
- 网易云 / QQ音乐 / 酷狗复用现有 LyricsCapability
- CJK / 假名 / 韩文视觉宽度感知拆分，1.5 秒 Focus 更新节流
- 暂不引入 Halcyon 的 Shizuku/XMSF 网络阻断 workaround，优先使用标准 Focus V3 路径

### Lyricon / 词幕 Provider
- 使用当前官方 SDK：`io.github.proify.lyricon:provider:0.1.70`
- MeloX 注册为 `lyricon_module`，声明 `$syllable` / `$translation` 能力
- 按官方架构选择 **Provider**：MeloX 向词幕发布自己的播放器状态；Subscriber 用于读取其他 Provider，因此不反向接入
- 应用进程启动后创建并注册 Lyricon Provider，`autoSync=true`，中心服务连接/重连后自动同步最近缓存状态
- 从 MeloX MediaSession 同步稳定歌曲 ID、歌名、歌手、总时长、播放/暂停和 250ms 播放位置
- 网易云 / QQ音乐 / 酷狗统一通过现有歌词能力加载
- `LyricsDocument` -> `Song / RichLyricLine / LyricWord`：保留真实逐字时间、行时间、翻译与罗马音；普通 LRC 保持行级时间轴
- 结构化歌词就绪后按官方推荐顺序重新同步：歌曲 -> 播放位置 -> 播放状态 -> 翻译/罗马音显示状态
- 系统歌词模式改写 Media3 标题时恢复保存的原始歌曲标题/歌手；专辑名保持原始 album metadata，不再误写为歌手
- 词幕翻译/罗马音显示开关直接跟随 MeloX 当前歌词设置，不新增第二套设置

### Manifest / 兼容
- Lyricon module metadata 与 tags 已加入 Manifest/resources
- Lyricon Provider Bridge 在 Android 8.1 以下按官方实现返回空实现；MeloX 仍保持 `minSdk 26`

### 构建状态
- 版本：`0.3.1-Dev` (`versionCode=4`)
- 最终联合 CI：GitHub Actions run `31661190861` / #404
- `testDebugUnitTest`：通过
- `assembleDebug`：通过
- Debug APK artifact：上传成功

保持 Draft，等待 HyperOS 3 与 Lyricon 真机回归后再考虑合并。