### PR TITLE
feat: add HyperOS Super Island lyrics and Lyricon provider

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -70,6 +70,13 @@ dependencies {
     implementation("io.github.proify.lyricon:provider:0.1.70")
     // HyperOS Focus / Super Island notification payload builder.
     implementation("com.xzakota.hyper.notification:focus-api:1.4")
+    // Optional non-root HyperOS compatibility path. If Shizuku is unavailable or
+    // permission is denied, MeloX continues publishing Focus notifications directly.
+    implementation("dev.rikka.shizuku:api:13.1.5")
+    implementation("dev.rikka.shizuku:provider:13.1.5")
+    // Framework Binder signatures used only at compile time. Android supplies the
+    // real hidden interfaces at runtime; this module is never packaged in the APK.
+    compileOnly(project(":hidden-api"))
 
     testImplementation("junit:junit:4.13.2")
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.lladlam.melox.android"
         minSdk = 26
         targetSdk = 37
-        versionCode = 3
-        versionName = "0.3.0-Dev"
+        versionCode = 4
+        versionName = "0.3.1-Dev"
     }
 
     buildFeatures {
@@ -65,6 +65,11 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:5.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("com.google.zxing:core:3.5.4")
+
+    // External lyric integrations.
+    implementation("io.github.proify.lyricon:provider:0.1.70")
+    // HyperOS Focus / Super Island notification payload builder.
+    implementation("com.xzakota.hyper.notification:focus-api:1.4")
 
     testImplementation("junit:junit:4.13.2")
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- focus-api itself declares API 27. MeloX only invokes it behind the
+         Android 8.1 + HyperOS 3 runtime guard in HyperOsFocusBridge, so the
+         app can safely keep its existing API 26 fallback support. -->
+    <uses-sdk tools:overrideLibrary="com.xzakota.hyper.notification.focus" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="moe.shizuku.manager.permission.API_V23" />
 
     <application
         android:allowBackup="true"
@@ -53,6 +54,15 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/melox_file_paths" />
         </provider>
+
+        <provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:enabled="true"
+            android:exported="true"
+            android:multiprocess="false"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+        <meta-data android:name="moe.shizuku.client.V3_SUPPORT" android:value="true" />
 
         <service
             android:name=".playback.MeloXPlaybackService"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,5 +65,14 @@
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Shows the currently playing lyric in a user-enabled overlay." />
         </service>
+
+        <meta-data android:name="lyricon_module" android:value="true" />
+        <meta-data android:name="lyricon_module_author" android:value="lladlam" />
+        <meta-data
+            android:name="lyricon_module_description"
+            android:value="MeloX player lyrics provider with word timing and translation support" />
+        <meta-data
+            android:name="lyricon_module_tags"
+            android:resource="@array/lyricon_module_tags" />
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/lladlam/melox/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import com.lladlam.melox.playback.MeloXListenTogetherCoordinator
 import com.lladlam.melox.core.network.parseNeteaseListenTogetherInvitation
 import com.lladlam.melox.platform.lyricon.MeloXLyriconBridge
+import com.lladlam.melox.platform.xiaomi.HyperOsFocusBridge
 import com.lladlam.melox.ui.player.MeloXListenTogetherInviteActivity
 import com.lladlam.melox.ui.MeloXApp
 import com.lladlam.melox.ui.settings.MeloXSettingsPreferences
@@ -53,6 +54,11 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+        // Shizuku is optional. On HyperOS 3, request permission only when its
+        // service is actually running; permission itself acts as the user's opt-in
+        // to the short XMSF compatibility pulse used by some restricted ROM builds.
+        HyperOsFocusBridge.prepareShizukuCompatibility(this)
+
         if (!com.lladlam.melox.ui.settings.MeloXSettingsRuntime.clipboardLinksEnabled) return
         val manager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val text = manager.primaryClip?.getItemAt(0)?.coerceToText(this)?.toString()?.trim().orEmpty()

--- a/android/app/src/main/kotlin/com/lladlam/melox/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.lladlam.melox.playback.MeloXListenTogetherCoordinator
 import com.lladlam.melox.core.network.parseNeteaseListenTogetherInvitation
+import com.lladlam.melox.platform.lyricon.MeloXLyriconBridge
 import com.lladlam.melox.ui.player.MeloXListenTogetherInviteActivity
 import com.lladlam.melox.ui.MeloXApp
 import com.lladlam.melox.ui.settings.MeloXSettingsPreferences
@@ -28,6 +29,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         consumePlaybackIntent(intent)
         MeloXSettingsPreferences.initialize(this)
+        MeloXLyriconBridge.start(applicationContext)
         // Restore/monitor an existing NetEase Together session as soon as the app
         // process starts, rather than waiting for the song actions sheet to open.
         MeloXListenTogetherCoordinator.ensureStarted(applicationContext)

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/lyricon/MeloXLyriconBridge.kt
@@ -1,0 +1,187 @@
+package com.lladlam.melox.platform.lyricon
+
+import android.content.ComponentName
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.lladlam.melox.core.lyrics.LyricLine
+import com.lladlam.melox.core.lyrics.LyricSyllable
+import com.lladlam.melox.core.lyrics.LyricsDocument
+import com.lladlam.melox.playback.MeloXPlaybackService
+import com.lladlam.melox.ui.player.MeloXPlaybackUiState
+import com.lladlam.melox.ui.player.MeloXProviderLyricsLoader
+import io.github.proify.lyricon.lyric.model.LyricWord
+import io.github.proify.lyricon.lyric.model.RichLyricLine
+import io.github.proify.lyricon.lyric.model.Song
+import io.github.proify.lyricon.provider.LyriconFactory
+import io.github.proify.lyricon.provider.LyriconProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Bridges MeloX's provider-neutral Media3 playback/lyrics state into Lyricon.
+ *
+ * One MediaController is kept for the application process. Lyrics are loaded only when the
+ * media id changes, then sent as a complete Song/RichLyricLine timeline. Playback position and
+ * playing state are lightweight shared-memory updates, so Lyricon can render word-timed lyrics
+ * without MeloX broadcasting a new line every frame.
+ */
+object MeloXLyriconBridge {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    @Volatile
+    private var started = false
+    private var provider: LyriconProvider? = null
+    private var playbackState: MeloXPlaybackUiState? = null
+    private var syncJob: Job? = null
+    private var lyricLoadJob: Job? = null
+
+    @Synchronized
+    fun start(context: Context) {
+        if (started) return
+        started = true
+
+        val appContext = context.applicationContext
+        val lyriconProvider = LyriconFactory.createProvider(appContext).apply {
+            autoSync = true
+            register()
+        }
+        provider = lyriconProvider
+
+        val state = MeloXPlaybackUiState(appContext)
+        playbackState = state
+        val token = SessionToken(
+            appContext,
+            ComponentName(appContext, MeloXPlaybackService::class.java),
+        )
+        val future = MediaController.Builder(appContext, token).buildAsync()
+        val handler = Handler(Looper.getMainLooper())
+        future.addListener(
+            {
+                runCatching { future.get() }
+                    .onSuccess { controller ->
+                        state.bind(controller)
+                        startSyncLoop(appContext, state, lyriconProvider)
+                    }
+            },
+            { command -> handler.post(command) },
+        )
+    }
+
+    private fun startSyncLoop(
+        context: Context,
+        state: MeloXPlaybackUiState,
+        lyriconProvider: LyriconProvider,
+    ) {
+        if (syncJob?.isActive == true) return
+        syncJob = scope.launch {
+            var observedMediaId: String? = null
+            var initialized = false
+
+            while (isActive) {
+                state.refresh()
+                val mediaId = state.mediaId
+                if (!initialized || mediaId != observedMediaId) {
+                    initialized = true
+                    observedMediaId = mediaId
+                    lyricLoadJob?.cancel()
+
+                    if (mediaId == null) {
+                        lyriconProvider.player.setSong(null)
+                    } else {
+                        val requestedMediaId = mediaId
+                        val title = state.title
+                        val artist = state.artist
+                        val durationMs = state.durationMs
+                        lyricLoadJob = scope.launch {
+                            val document = runCatching {
+                                MeloXProviderLyricsLoader.load(context, state)
+                            }.getOrElse { LyricsDocument(emptyList()) }
+                            if (state.mediaId != requestedMediaId) return@launch
+
+                            lyriconProvider.player.setSong(
+                                document.toLyriconSong(
+                                    mediaId = requestedMediaId,
+                                    title = title,
+                                    artist = artist,
+                                    durationMs = durationMs,
+                                ),
+                            )
+                            lyriconProvider.player.setDisplayTranslation(
+                                document.lines.any { !it.translation.isNullOrBlank() },
+                            )
+                            lyriconProvider.player.setDisplayRoma(
+                                document.lines.any { !it.romanization.isNullOrBlank() },
+                            )
+                            lyriconProvider.player.setPlaybackState(state.isPlaying)
+                            lyriconProvider.player.setPosition(state.positionMs.coerceAtLeast(0L))
+                        }
+                    }
+                }
+
+                lyriconProvider.player.setPlaybackState(state.isPlaying)
+                lyriconProvider.player.setPosition(state.positionMs.coerceAtLeast(0L))
+                delay(if (state.isPlaying) 500L else 1_000L)
+            }
+        }
+    }
+
+    private fun LyricsDocument.toLyriconSong(
+        mediaId: String,
+        title: String,
+        artist: String,
+        durationMs: Long,
+    ): Song {
+        val richLines = lines.mapIndexedNotNull { index, line ->
+            line.toLyriconLine(lines.getOrNull(index + 1)?.timeMs)
+        }
+        return Song(
+            id = mediaId,
+            name = title.ifBlank { null },
+            artist = artist.ifBlank { null },
+            duration = durationMs.coerceAtLeast(0L),
+            lyrics = richLines,
+        )
+    }
+
+    private fun LyricLine.toLyriconLine(nextStartMs: Long?): RichLyricLine? {
+        val cleanText = text.trim()
+        if (cleanText.isBlank()) return null
+
+        val beginMs = timeMs.coerceAtLeast(0L)
+        val inferredDuration = durationMs
+            ?: nextStartMs?.minus(beginMs)?.takeIf { it > 0L }
+            ?: 3_000L
+        val endMs = (beginMs + inferredDuration.coerceAtLeast(1L)).coerceAtLeast(beginMs + 1L)
+
+        return RichLyricLine(
+            begin = beginMs,
+            end = endMs,
+            duration = endMs - beginMs,
+            text = text,
+            words = syllables.toLyriconWords(),
+            translation = translation,
+            roma = romanization,
+        )
+    }
+
+    private fun List<LyricSyllable>.toLyriconWords(): List<LyricWord>? =
+        takeIf { it.isNotEmpty() }?.mapNotNull { syllable ->
+            val text = syllable.text.takeIf(String::isNotEmpty) ?: return@mapNotNull null
+            val beginMs = syllable.startTimeMs.coerceAtLeast(0L)
+            val endMs = syllable.endTimeMs.coerceAtLeast(beginMs + 1L)
+            LyricWord(
+                begin = beginMs,
+                end = endMs,
+                duration = endMs - beginMs,
+                text = text,
+            )
+        }?.takeIf { it.isNotEmpty() }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import com.xzakota.hyper.notification.focus.FocusNotification
@@ -39,7 +40,8 @@ object HyperOsFocusBridge {
     }
 
     fun supportsSuperIsland(context: Context): Boolean =
-        protocol(context) == Protocol.HyperOs3
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 &&
+            protocol(context) == Protocol.HyperOs3
 
     /**
      * Publishes the dedicated Focus V3 notification as a side effect.

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -44,6 +44,16 @@ object HyperOsFocusBridge {
             protocol(context) == Protocol.HyperOs3
 
     /**
+     * Ask Shizuku for access only when HyperOS 3 and a live Shizuku service are present.
+     * Missing Shizuku, a denied request, or an incompatible firewall backend simply leaves
+     * the already-working direct Focus path untouched.
+     */
+    fun prepareShizukuCompatibility(context: Context) {
+        if (!supportsSuperIsland(context)) return
+        ShizukuXmsfNetworkHelper.prepare(context.applicationContext)
+    }
+
+    /**
      * Publishes the dedicated Focus V3 notification as a side effect.
      *
      * The return type stays Bundle-compatible with the legacy call site, but this method returns
@@ -137,8 +147,11 @@ object HyperOsFocusBridge {
             .addExtras(focusExtras)
             .build()
 
-        appContext.getSystemService(NotificationManager::class.java)
-            .notify(SUPER_ISLAND_NOTIFICATION_ID, notification)
+        ShizukuXmsfNetworkHelper.dispatchFocusNotification(
+            context = appContext,
+            notificationId = SUPER_ISLAND_NOTIFICATION_ID,
+            notification = notification,
+        )
         return null
     }
 
@@ -148,9 +161,10 @@ object HyperOsFocusBridge {
 
     fun clearSuperIsland(context: Context) {
         lastPublishedKey = null
-        context.applicationContext
-            .getSystemService(NotificationManager::class.java)
-            .cancel(SUPER_ISLAND_NOTIFICATION_ID)
+        ShizukuXmsfNetworkHelper.clearFocusNotification(
+            context.applicationContext,
+            SUPER_ISLAND_NOTIFICATION_ID,
+        )
     }
 
     private fun ensureSuperIslandChannel(context: Context) {

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/HyperOsFocusBridge.kt
@@ -1,39 +1,53 @@
 package com.lladlam.melox.platform.xiaomi
 
 import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.os.Bundle
 import android.provider.Settings
-import org.json.JSONObject
+import com.xzakota.hyper.notification.focus.FocusNotification
+import com.xzakota.hyper.notification.island.model.BigIslandArea
+import com.xzakota.hyper.notification.island.model.TextInfo
 
 /**
- * Xiaomi HyperOS integration boundary.
+ * Xiaomi HyperOS Focus / Super Island lyric integration.
  *
- * Normal music playback should continue to use Android MediaSession/Media3.
- * This bridge is reserved for HyperOS focus notifications / Super Island
- * scenarios that do not map cleanly to the standard media notification.
+ * The Focus V3 payload shape is adapted from Kifranei/Halcyon (Apache-2.0),
+ * then reduced to MeloX's provider-neutral playback metadata and lyric stream.
+ * A dedicated HIGH-importance, silent notification channel is intentionally used:
+ * Android cannot promote the existing LOW lyric channel after it has been created,
+ * while HyperOS requires a Focus-capable channel for Super Island rendering.
  */
 object HyperOsFocusBridge {
     private const val FOCUS_PROTOCOL_SETTING = "notification_focus_protocol"
-    private const val FOCUS_PARAM_KEY = "miui.focus.param"
+    private const val SUPER_ISLAND_CHANNEL = "melox_super_island_lyrics_v1"
+    private const val SUPER_ISLAND_NOTIFICATION_ID = 1703
+
+    @Volatile
+    private var lastPublishedKey: String? = null
 
     enum class Protocol(val version: Int) {
-        Unsupported(0),
-        HyperOs1(1),
-        HyperOs2(2),
-        HyperOs3(3),
+        Unsupported(0), HyperOs1(1), HyperOs2(2), HyperOs3(3),
     }
 
     fun protocol(context: Context): Protocol {
         val version = runCatching {
             Settings.System.getInt(context.contentResolver, FOCUS_PROTOCOL_SETTING, 0)
         }.getOrDefault(0)
-        return Protocol.entries.firstOrNull { it.version == version }
-            ?: Protocol.Unsupported
+        return Protocol.entries.firstOrNull { it.version == version } ?: Protocol.Unsupported
     }
 
     fun supportsSuperIsland(context: Context): Boolean =
         protocol(context) == Protocol.HyperOs3
 
+    /**
+     * Publishes the dedicated Focus V3 notification as a side effect.
+     *
+     * The return type stays Bundle-compatible with the legacy call site, but this method returns
+     * null after publishing so the same Focus extras are not attached a second time to MeloX's
+     * ordinary LOW-priority lyric notification.
+     */
     fun playbackPayload(
         context: Context,
         lyric: String,
@@ -42,33 +56,144 @@ object HyperOsFocusBridge {
         positionMs: Long,
         durationMs: Long,
         isPlaying: Boolean,
-    ): String? {
-        val protocol = protocol(context)
-        if (protocol == Protocol.Unsupported) return null
-        return JSONObject().apply {
-            put("protocolVersion", protocol.version)
-            put("scene", "music")
-            put("source", "MeloX")
-            put("title", lyric)
-            put("song", songTitle)
-            put("artist", artist)
-            put("position", positionMs.coerceAtLeast(0L))
-            put("duration", durationMs.coerceAtLeast(0L))
-            put("playing", isPlaying)
-            if (protocol == Protocol.HyperOs3) put("superIsland", true)
-        }.toString()
+    ): Bundle? {
+        if (!supportsSuperIsland(context)) return null
+
+        val text = lyric.trim()
+        if (text.isBlank()) {
+            clearSuperIsland(context)
+            return null
+        }
+
+        val progress = if (durationMs > 0L) {
+            ((positionMs.coerceIn(0L, durationMs) * 100L) / durationMs)
+                .toInt()
+                .coerceIn(0, 100)
+        } else {
+            0
+        }
+        val key = listOf(songTitle, artist, text, progress / 2, isPlaying).joinToString("|")
+        if (key == lastPublishedKey) return null
+        lastPublishedKey = key
+
+        val appContext = context.applicationContext
+        ensureSuperIslandChannel(appContext)
+
+        val focusExtras = FocusNotification.buildV3 {
+            business = "lyric_display"
+            isShowNotification = true
+            enableFloat = false
+            updatable = true
+            islandFirstFloat = false
+            aodTitle = text.take(20).ifBlank { "♪" }
+            ticker = text
+
+            chatInfo {
+                title = text
+                content = songLabel(songTitle, artist)
+                appIconPkg = appContext.packageName
+            }
+
+            progressInfo {
+                this.progress = progress
+                colorProgress = "#FF757575"
+                colorProgressEnd = "#FF757575"
+            }
+
+            island {
+                islandProperty = 1
+                bigIslandArea {
+                    applyMeloXLyric(
+                        lyric = text,
+                        songTitle = songTitle,
+                        artist = artist,
+                    )
+                }
+                smallIslandArea {
+                    combinePicInfo {
+                        progressInfo {
+                            this.progress = progress
+                            colorReach = "#FF757575"
+                            colorUnReach = "#333333"
+                        }
+                    }
+                }
+            }
+        }
+
+        val notification = Notification.Builder(appContext, SUPER_ISLAND_CHANNEL)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle(text)
+            .setContentText(songLabel(songTitle, artist))
+            .setCategory(Notification.CATEGORY_TRANSPORT)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+            .setShowWhen(false)
+            .setOnlyAlertOnce(true)
+            .setLocalOnly(true)
+            .setOngoing(isPlaying)
+            .setTimeoutAfter(if (isPlaying) 15_000L else 5_000L)
+            .addExtras(focusExtras)
+            .build()
+
+        appContext.getSystemService(NotificationManager::class.java)
+            .notify(SUPER_ISLAND_NOTIFICATION_ID, notification)
+        return null
     }
 
-    /**
-     * Attaches Xiaomi's documented focus-notification payload to an already
-     * built Android notification. Callers remain responsible for Xiaomi's
-     * scene approval/permission requirements and for providing a valid JSON
-     * payload for the target HyperOS protocol.
-     */
-    fun attachFocusParams(
-        notification: Notification,
-        islandParamsJson: String,
-    ): Notification = notification.apply {
-        extras.putString(FOCUS_PARAM_KEY, islandParamsJson)
+    /** Kept for source compatibility with the previous bridge contract. */
+    fun attachFocusParams(notification: Notification, focusExtras: Bundle): Notification =
+        notification.apply { extras.putAll(focusExtras) }
+
+    fun clearSuperIsland(context: Context) {
+        lastPublishedKey = null
+        context.applicationContext
+            .getSystemService(NotificationManager::class.java)
+            .cancel(SUPER_ISLAND_NOTIFICATION_ID)
     }
+
+    private fun ensureSuperIslandChannel(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(SUPER_ISLAND_CHANNEL) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                SUPER_ISLAND_CHANNEL,
+                "HyperOS 岛歌词",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "在 HyperOS 超级岛显示当前歌词"
+                setSound(null, null)
+                enableVibration(false)
+                setShowBadge(false)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            },
+        )
+    }
+
+    private fun BigIslandArea.applyMeloXLyric(
+        lyric: String,
+        songTitle: String,
+        artist: String,
+    ) {
+        val left = songLabel(songTitle, artist).ifBlank { "MeloX" }.take(24)
+        val right = lyric.take(42).ifBlank { "♪" }
+        imageTextInfoLeft {
+            type = 1
+            textInfo {
+                title = left
+                showHighlightColor = false
+                narrowFont = false
+            }
+        }
+        textInfo = TextInfo().apply {
+            title = right
+            showHighlightColor = false
+            narrowFont = false
+        }
+    }
+
+    private fun songLabel(songTitle: String, artist: String): String =
+        listOf(songTitle.trim(), artist.trim())
+            .filter(String::isNotBlank)
+            .joinToString(" · ")
+            .ifBlank { "MeloX" }
 }

--- a/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/ShizukuXmsfNetworkHelper.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/platform/xiaomi/ShizukuXmsfNetworkHelper.kt
@@ -1,0 +1,420 @@
+package com.lladlam.melox.platform.xiaomi
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.IConnectivityManager
+import android.os.IBinder
+import android.os.INetworkManagementService
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import rikka.shizuku.Shizuku
+import rikka.shizuku.ShizukuBinderWrapper
+import rikka.shizuku.SystemServiceHelper
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.resume
+
+/**
+ * Optional Shizuku-backed XMSF compatibility path for HyperOS Super Island.
+ *
+ * Some HyperOS builds accept third-party Focus notifications directly; others appear to race
+ * Xiaomi's XMSF handling. When the user explicitly grants MeloX Shizuku access, this helper
+ * applies the same short OEM firewall pulse used by Halcyon: block XMSF, publish the Focus
+ * notification, wait 100 ms, then restore the default rule. No Shizuku means no firewall
+ * changes at all -- the notification is published directly.
+ */
+internal object ShizukuXmsfNetworkHelper {
+    private const val TAG = "MeloXShizukuIsland"
+    private const val XMSF_PACKAGE = "com.xiaomi.xmsf"
+    private const val OEM_DENY_CHAIN = 9
+    private const val RULE_DEFAULT = 0
+    private const val RULE_ALLOW = 1
+    private const val RULE_DENY = 2
+    private const val MAX_RETRIES = 2
+    private const val RETRY_DELAY_MS = 500L
+    private const val XMSF_PULSE_MS = 100L
+
+    private data class ServiceBackend(
+        val serviceName: String,
+        val stubClassName: String,
+        val label: String,
+    )
+
+    private val backends = listOf(
+        ServiceBackend("connectivity", "android.net.IConnectivityManager\$Stub", "ConnectivityManager"),
+        ServiceBackend("network_management", "android.os.INetworkManagementService\$Stub", "NetworkManagementService"),
+    )
+
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val permissionScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val networkMutex = Mutex()
+    private val wrappedServices = ConcurrentHashMap<String, Any>()
+
+    @Volatile
+    private var permissionRequestAttempted = false
+    @Volatile
+    private var dispatchGeneration = 0L
+    @Volatile
+    private var xmsfNetworkingBlocked = false
+
+    private var permissionProbeJob: Job? = null
+    private var dispatchJob: Job? = null
+    private var nextRequestCode = 1200
+
+    /**
+     * Called only while MeloX is foregrounded. If Shizuku is running, request permission once
+     * for this process. Users without Shizuku never see a prompt and remain on direct Focus.
+     */
+    fun prepare(context: Context) {
+        if (hasPermission()) {
+            restoreXmsfNetworkingAsync(context.applicationContext)
+            return
+        }
+        synchronized(this) {
+            if (permissionRequestAttempted || permissionProbeJob?.isActive == true) return
+            permissionProbeJob = permissionScope.launch {
+                repeat(8) {
+                    if (runCatching { Shizuku.pingBinder() }.getOrDefault(false)) {
+                        permissionRequestAttempted = true
+                        if (ensureShizukuPermission()) {
+                            restoreXmsfNetworkingAsync(context.applicationContext)
+                        }
+                        return@launch
+                    }
+                    delay(250L)
+                }
+            }
+        }
+    }
+
+    /** Publish directly unless Shizuku permission is already granted. */
+    fun dispatchFocusNotification(
+        context: Context,
+        notificationId: Int,
+        notification: Notification,
+    ) {
+        val appContext = context.applicationContext
+        val manager = appContext.getSystemService(NotificationManager::class.java)
+        if (!hasPermission()) {
+            publishDirect(manager, notificationId, notification)
+            return
+        }
+
+        val generation = synchronized(this) {
+            dispatchGeneration += 1L
+            dispatchJob?.cancel()
+            dispatchGeneration
+        }
+        dispatchJob = ioScope.launch {
+            networkMutex.withLock {
+                if (generation != dispatchGeneration) return@withLock
+
+                val blocked = withContext(NonCancellable) {
+                    setXmsfNetworkingEnabled(appContext, enabled = false)
+                }
+                if (!blocked) {
+                    publishDirect(manager, notificationId, notification)
+                    return@withLock
+                }
+                xmsfNetworkingBlocked = true
+
+                try {
+                    if (generation == dispatchGeneration) {
+                        publishDirect(manager, notificationId, notification)
+                    }
+                    delay(XMSF_PULSE_MS)
+                } catch (_: CancellationException) {
+                    // A newer lyric owns the next pulse. finally still restores XMSF first.
+                } finally {
+                    withContext(NonCancellable) {
+                        restoreXmsfNetworking()
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearFocusNotification(context: Context, notificationId: Int) {
+        synchronized(this) {
+            dispatchGeneration += 1L
+            dispatchJob?.cancel()
+            dispatchJob = null
+        }
+        context.applicationContext
+            .getSystemService(NotificationManager::class.java)
+            .cancel(notificationId)
+        restoreXmsfNetworkingAsync(context.applicationContext)
+    }
+
+    private fun publishDirect(
+        manager: NotificationManager,
+        notificationId: Int,
+        notification: Notification,
+    ) {
+        runCatching { manager.notify(notificationId, notification) }
+            .onFailure { Log.w(TAG, "Unable to publish Focus notification", it) }
+    }
+
+    private fun hasPermission(): Boolean =
+        runCatching { Shizuku.pingBinder() }.getOrDefault(false) &&
+            runCatching { Shizuku.checkSelfPermission() }.getOrDefault(PackageManager.PERMISSION_DENIED) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private suspend fun ensureShizukuPermission(): Boolean = withContext(Dispatchers.Main.immediate) {
+        if (!runCatching { Shizuku.pingBinder() }.getOrDefault(false)) return@withContext false
+        if (runCatching { Shizuku.checkSelfPermission() }.getOrDefault(PackageManager.PERMISSION_DENIED) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return@withContext true
+        }
+
+        suspendCancellableCoroutine { continuation ->
+            val requestCode = synchronized(this@ShizukuXmsfNetworkHelper) {
+                nextRequestCode = (nextRequestCode + 1).coerceAtLeast(1201)
+                nextRequestCode
+            }
+            lateinit var listener: Shizuku.OnRequestPermissionResultListener
+            listener = Shizuku.OnRequestPermissionResultListener { returnedCode, result ->
+                if (returnedCode != requestCode || !continuation.isActive) return@OnRequestPermissionResultListener
+                Shizuku.removeRequestPermissionResultListener(listener)
+                continuation.resume(result == PackageManager.PERMISSION_GRANTED)
+            }
+            Shizuku.addRequestPermissionResultListener(listener)
+            continuation.invokeOnCancellation {
+                Shizuku.removeRequestPermissionResultListener(listener)
+            }
+            runCatching { Shizuku.requestPermission(requestCode) }
+                .onFailure {
+                    Shizuku.removeRequestPermissionResultListener(listener)
+                    if (continuation.isActive) continuation.resume(false)
+                }
+        }
+    }
+
+    private fun restoreXmsfNetworkingAsync(context: Context) {
+        ioScope.launch {
+            networkMutex.withLock {
+                if (xmsfNetworkingBlocked || hasPermission()) {
+                    withContext(NonCancellable) { restoreXmsfNetworking() }
+                }
+            }
+        }
+    }
+
+    private suspend fun restoreXmsfNetworking() {
+        if (!xmsfNetworkingBlocked && !hasPermission()) return
+        val restored = setXmsfNetworkingEnabledInternal(enabled = true)
+        if (restored) {
+            xmsfNetworkingBlocked = false
+        } else if (xmsfNetworkingBlocked) {
+            Log.w(TAG, "XMSF restore was requested but no compatible backend was available")
+        }
+    }
+
+    private suspend fun setXmsfNetworkingEnabled(context: Context, enabled: Boolean): Boolean {
+        val appContext = context.applicationContext
+        val uid = runCatching { appContext.packageManager.getPackageUid(XMSF_PACKAGE, 0) }
+            .getOrElse {
+                Log.i(TAG, "XMSF is not installed")
+                return false
+            }
+        if (!hasPermission()) return false
+        return applyFirewallRuleWithRetry(uid, enabled)
+    }
+
+    private suspend fun setXmsfNetworkingEnabledInternal(enabled: Boolean): Boolean {
+        if (!hasPermission()) return false
+        // System package UID is stable for the current boot. Resolve it through a small context-free
+        // shell-compatible fallback only when a previous pulse actually marked XMSF blocked.
+        val uid = currentXmsfUid ?: return false
+        return applyFirewallRuleWithRetry(uid, enabled)
+    }
+
+    @Volatile
+    private var currentXmsfUid: Int? = null
+
+    private suspend fun applyFirewallRuleWithRetry(uid: Int, enabled: Boolean): Boolean =
+        withContext(Dispatchers.IO) {
+            currentXmsfUid = uid
+            var lastFailure: Throwable? = null
+            repeat(MAX_RETRIES) { attempt ->
+                try {
+                    applyFirewallRule(uid, enabled)
+                    Log.d(TAG, "XMSF networking ${if (enabled) "restored" else "blocked"} for uid=$uid")
+                    return@withContext true
+                } catch (error: Throwable) {
+                    lastFailure = error
+                    wrappedServices.clear()
+                    if (attempt + 1 < MAX_RETRIES) delay(RETRY_DELAY_MS)
+                }
+            }
+            Log.w(TAG, "No compatible XMSF firewall backend", lastFailure)
+            false
+        }
+
+    private fun hookedConnectivityManager(): IConnectivityManager {
+        val originalBinder = SystemServiceHelper.getSystemService(Context.CONNECTIVITY_SERVICE)
+            ?: error("connectivity binder is null")
+        val original = IConnectivityManager.Stub.asInterface(originalBinder)
+            ?: error("ConnectivityManager unavailable")
+        return IConnectivityManager.Stub.asInterface(ShizukuBinderWrapper(original.asBinder()))
+            ?: error("ConnectivityManager wrapper unavailable")
+    }
+
+    private fun hookedNetworkManagementService(): INetworkManagementService {
+        val originalBinder = SystemServiceHelper.getSystemService("network_management")
+            ?: error("network_management binder is null")
+        val original = INetworkManagementService.Stub.asInterface(originalBinder)
+            ?: error("NetworkManagementService unavailable")
+        return INetworkManagementService.Stub.asInterface(ShizukuBinderWrapper(original.asBinder()))
+            ?: error("NetworkManagementService wrapper unavailable")
+    }
+
+    private fun applyFirewallRule(uid: Int, enabled: Boolean) {
+        runCatching {
+            val service = hookedConnectivityManager()
+            val rule = if (enabled) RULE_DEFAULT else RULE_DENY
+            if (!enabled) service.setFirewallChainEnabled(OEM_DENY_CHAIN, true)
+            service.setUidFirewallRule(OEM_DENY_CHAIN, uid, rule)
+            return
+        }.onFailure { typedConnectivityFailure ->
+            Log.w(TAG, "Typed connectivity firewall path failed; trying legacy binder", typedConnectivityFailure)
+            runCatching {
+                val service = hookedNetworkManagementService()
+                val rule = if (enabled) RULE_DEFAULT else RULE_DENY
+                if (!enabled) service.setFirewallChainEnabled(OEM_DENY_CHAIN, true)
+                service.setUidFirewallRule(OEM_DENY_CHAIN, uid, rule)
+                return
+            }.onFailure { typedLegacyFailure ->
+                Log.w(TAG, "Typed network-management path failed; trying reflection", typedLegacyFailure)
+            }
+        }
+
+        val failures = mutableListOf<String>()
+        for (backend in backends) {
+            try {
+                applyFirewallRule(getWrappedService(backend), uid, enabled)
+                return
+            } catch (error: Throwable) {
+                failures += "${backend.label}: ${error.message ?: error.javaClass.name}"
+            }
+        }
+        error("No compatible firewall backend. ${failures.joinToString(" | ")}")
+    }
+
+    private fun applyFirewallRule(service: Any, uid: Int, enabled: Boolean) {
+        val failures = mutableListOf<String>()
+        if (!enabled) {
+            runCatching { call(service, listOf("setFirewallChainEnabled"), OEM_DENY_CHAIN, true) }
+                .onFailure { failures += "chain: ${it.message}" }
+        }
+
+        val modernRule = if (enabled) RULE_DEFAULT else RULE_DENY
+        val modernAttempts = listOf<() -> Unit>(
+            { call(service, listOf("setUidFirewallRule", "setFirewallUidRule"), OEM_DENY_CHAIN, uid, modernRule) },
+            { call(service, listOf("setUidFirewallRules", "setFirewallUidRules"), OEM_DENY_CHAIN, intArrayOf(uid), intArrayOf(modernRule)) },
+        )
+        if (runAttempts(modernAttempts, failures)) return
+
+        if (!enabled) {
+            runCatching { call(service, listOf("setFirewallEnabled"), true) }
+                .onFailure { failures += "legacy chain: ${it.message}" }
+        }
+        val legacyRule = if (enabled) RULE_ALLOW else RULE_DENY
+        val legacyAttempts = listOf<() -> Unit>(
+            { call(service, listOf("setUidFirewallRule", "setFirewallUidRule"), uid, enabled) },
+            { call(service, listOf("setUidFirewallRule", "setFirewallUidRule"), uid, legacyRule) },
+            { call(service, listOf("setUidFirewallRules", "setFirewallUidRules"), intArrayOf(uid), intArrayOf(legacyRule)) },
+        )
+        if (runAttempts(legacyAttempts, failures)) return
+        error("No compatible firewall method on ${service.javaClass.name}: ${failures.joinToString(" | ")}")
+    }
+
+    private fun runAttempts(attempts: List<() -> Unit>, failures: MutableList<String>): Boolean {
+        attempts.forEach { attempt ->
+            try {
+                attempt()
+                return true
+            } catch (error: Throwable) {
+                failures += error.message ?: error.javaClass.name
+            }
+        }
+        return false
+    }
+
+    private fun getWrappedService(backend: ServiceBackend): Any =
+        wrappedServices[backend.serviceName] ?: synchronized(this) {
+            wrappedServices[backend.serviceName] ?: run {
+                val binder = SystemServiceHelper.getSystemService(backend.serviceName)
+                    ?: error("${backend.serviceName} binder is null")
+                val stub = Class.forName(backend.stubClassName)
+                val asInterface = stub.getMethod("asInterface", IBinder::class.java)
+                val original = asInterface.invoke(null, binder) ?: error("${backend.label} unavailable")
+                val originalBinder = original.javaClass.getMethod("asBinder").invoke(original) as? IBinder
+                    ?: error("${backend.label} binder unavailable")
+                val wrapped = asInterface.invoke(null, ShizukuBinderWrapper(originalBinder))
+                    ?: error("${backend.label} wrapper unavailable")
+                wrappedServices[backend.serviceName] = wrapped
+                wrapped
+            }
+        }
+
+    private fun call(target: Any, names: List<String>, vararg args: Any) {
+        val methods = names.flatMap { name ->
+            target.javaClass.methods.filter { it.name == name && it.parameterCount == args.size }
+        }
+        if (methods.isEmpty()) error("Missing ${names.joinToString()}(${args.size})")
+        var lastFailure: Throwable? = null
+        methods.forEach { method ->
+            try {
+                invoke(target, method, args)
+                return
+            } catch (error: Throwable) {
+                lastFailure = error
+            }
+        }
+        throw lastFailure ?: NoSuchMethodException(names.joinToString())
+    }
+
+    private fun invoke(target: Any, method: Method, args: Array<out Any>) {
+        method.isAccessible = true
+        val adapted = Array(args.size) { index ->
+            val expected = method.parameterTypes[index]
+            val value = args[index]
+            when {
+                expected == Int::class.javaPrimitiveType -> when (value) {
+                    is Boolean -> if (value) 1 else 0
+                    is Number -> value.toInt()
+                    else -> error("Unsupported int argument")
+                }
+                expected == Boolean::class.javaPrimitiveType -> when (value) {
+                    is Boolean -> value
+                    is Number -> value.toInt() != 0
+                    else -> error("Unsupported boolean argument")
+                }
+                expected == IntArray::class.java && value is IntArray -> value
+                expected.isInstance(value) -> value
+                else -> error("Argument does not match ${expected.name}")
+            }
+        }
+        try {
+            method.invoke(target, *adapted)
+        } catch (error: InvocationTargetException) {
+            throw error.targetException ?: error
+        }
+    }
+}

--- a/android/app/src/main/res/values/lyricon.xml
+++ b/android/app/src/main/res/values/lyricon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="lyricon_module_tags">
+        <item>$syllable</item>
+        <item>$translation</item>
+    </string-array>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("com.android.application") version "9.3.0" apply false
+    id("com.android.library") version "9.3.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
 }

--- a/android/hidden-api/build.gradle.kts
+++ b/android/hidden-api/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "com.lladlam.melox.hiddenapi"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/android/hidden-api/src/main/java/android/net/IConnectivityManager.java
+++ b/android/hidden-api/src/main/java/android/net/IConnectivityManager.java
@@ -1,0 +1,22 @@
+package android.net;
+
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+/**
+ * Compile-only signature for the system connectivity binder. Android supplies the real class
+ * at runtime; this stub must never be packaged with the application.
+ */
+public interface IConnectivityManager extends IInterface {
+    void setFirewallChainEnabled(int chain, boolean enable) throws RemoteException;
+
+    void setUidFirewallRule(int chain, int uid, int rule) throws RemoteException;
+
+    abstract class Stub extends Binder implements IConnectivityManager {
+        public static IConnectivityManager asInterface(IBinder obj) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/android/hidden-api/src/main/java/android/os/INetworkManagementService.java
+++ b/android/hidden-api/src/main/java/android/os/INetworkManagementService.java
@@ -1,0 +1,16 @@
+package android.os;
+
+/** Compile-only signature for the legacy network-management binder. */
+public interface INetworkManagementService extends IInterface {
+    void setFirewallChainEnabled(int chain, boolean enable) throws RemoteException;
+
+    void setUidFirewallRule(int chain, int uid, int rule) throws RemoteException;
+
+    void setFirewallUidRule(int chain, int uid, int rule) throws RemoteException;
+
+    abstract class Stub extends Binder implements INetworkManagementService {
+        public static INetworkManagementService asInterface(IBinder obj) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "MeloX-Android"
 include(":app")
+include(":hidden-api")


### PR DESCRIPTION
## Summary
- publish real HyperOS Focus V3 / Super Island lyric notifications on a dedicated silent HIGH-priority channel
- keep the existing ordinary MeloX lyric notification unchanged as fallback
- add optional Shizuku 13.1.5 compatibility for HyperOS builds that restrict third-party Focus islands
- when Shizuku is running, request permission while MeloX is foregrounded; a granted permission enables a short 100 ms XMSF firewall pulse around Focus publication
- if Shizuku is absent, stopped, denied, or no compatible firewall backend is available, publish the Focus notification directly with no feature loss
- use compile-only hidden Android Binder signatures for the Android 16 connectivity/network-management path; the stubs are not packaged in the APK
- add Lyricon Provider 0.1.70 integration using MeloX's provider-neutral Media3 playback state
- map full rich lyric timelines including word timing, translation and romanization
- declare Lyricon module metadata/capability tags
- bump Android to 0.3.1-Dev (versionCode 4)

## Architecture
- HyperOS Focus payload shape and the optional XMSF compatibility strategy are adapted from Kifranei/Halcyon (Apache-2.0), reduced to MeloX's existing playback metadata
- direct Focus remains the normal/fallback path; Shizuku is optional and never required for playback or lyrics
- Lyricon uses Provider (not Subscriber) because MeloX is the player/source
- NetEase, QQ Music and Kugou share the same MeloX playback/lyrics bridge
- no AutoMix implementation changes

## Validation
- GitHub Actions Android run #408: unit tests, debug APK build and artifact upload all passed
- Lyricon Provider and direct HyperOS Super Island were verified successfully on a real HyperOS device before adding the optional Shizuku path
- Shizuku permission/XMSF compatibility path still requires the final real-device authorization test before merge