### PR TITLE
feat: add native QQ Music QR login

### DIFF
--- a/android/app/src/main/kotlin/com/lladlam/melox/core/music/provider/ProviderAccountManager.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/music/provider/ProviderAccountManager.kt
@@ -15,7 +15,7 @@ import com.lladlam.melox.core.provider.jellyfin.JellyfinSessionStore
  * Small provider-neutral account facade used by settings/experience UI.
  *
  * It intentionally handles only local session state. Login flows remain
- * provider-specific because QQ Music uses WebView auth while Kugou uses QR auth.
+ * provider-specific because QQ Music and Kugou use different QR authorization protocols.
  */
 class ProviderAccountManager(
     context: Context,

--- a/android/app/src/main/kotlin/com/lladlam/melox/core/provider/qqmusic/QQMusicQrLoginClient.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/core/provider/qqmusic/QQMusicQrLoginClient.kt
@@ -1,0 +1,585 @@
+package com.lladlam.melox.core.provider.qqmusic
+
+import com.lladlam.melox.core.network.MeloXHttpClient
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.security.SecureRandom
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.FormBody
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+private const val QQ_QR_LOGIN_LIFETIME_MS = 2 * 60 * 1_000L
+private const val WECHAT_QR_LOGIN_LIFETIME_MS = 5 * 60 * 1_000L
+private const val QQ_QR_APP_ID = "716027609"
+private const val QQ_MUSIC_OAUTH_APP_ID = "100497308"
+private const val QQ_LOGIN_DAID = "383"
+private const val QQ_MUSIC_WECHAT_APP_ID = "wx48db31d50e334801"
+private const val QQ_MUSIC_WECHAT_REDIRECT_URL =
+    "https://y.qq.com/portal/wx_redirect.html?login_type=2&surl=https://y.qq.com/"
+private const val QQ_LOGIN_USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+        "Chrome/124.0.0.0 Safari/537.36 MeloX/0.5"
+
+internal enum class QQMusicQrLoginEvent {
+    Waiting,
+    Scanned,
+    Connected,
+    Expired,
+    Rejected,
+}
+
+internal data class QQMusicPtuiResult(
+    val event: QQMusicQrLoginEvent,
+    val message: String,
+    val uin: String = "",
+    val sigX: String = "",
+    val authorizationCode: String = "",
+)
+
+internal data class QQMusicQrCredential(
+    val musicId: String,
+    val musicKey: String,
+    val openId: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val unionId: String,
+    val encryptedUin: String,
+    val loginType: Int,
+)
+
+enum class QQMusicQrLoginMethod {
+    QQ,
+    WeChat,
+}
+
+class QQMusicQrLoginSession internal constructor(
+    val method: QQMusicQrLoginMethod,
+    val imageBytes: ByteArray,
+    val imageMimeType: String,
+    internal val qrToken: String,
+    internal val expiresAtMillis: Long,
+    internal val httpClient: OkHttpClient,
+    internal val cookieJar: QQMusicLoginCookieJar,
+) {
+    internal var lastWechatStatus: Int? = null
+}
+
+sealed interface QQMusicQrLoginState {
+    data object Waiting : QQMusicQrLoginState
+    data object Scanned : QQMusicQrLoginState
+    data object Expired : QQMusicQrLoginState
+    data object Rejected : QQMusicQrLoginState
+    data class Authorized(val cookie: String) : QQMusicQrLoginState
+}
+
+/** Native QQ QR authorization flow, ported from OmniMusic without a WebView. */
+class QQMusicQrLoginClient(
+    private val baseHttpClient: OkHttpClient = MeloXHttpClient.shared,
+    private val nowMillis: () -> Long = System::currentTimeMillis,
+) {
+    suspend fun createSession(
+        method: QQMusicQrLoginMethod = QQMusicQrLoginMethod.QQ,
+    ): QQMusicQrLoginSession = withContext(Dispatchers.IO) {
+        val cookieJar = QQMusicLoginCookieJar()
+        val client = baseHttpClient.newBuilder()
+            .cookieJar(cookieJar)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .callTimeout(35, TimeUnit.SECONDS)
+            .readTimeout(35, TimeUnit.SECONDS)
+            .build()
+        when (method) {
+            QQMusicQrLoginMethod.QQ -> createQQSession(client, cookieJar)
+            QQMusicQrLoginMethod.WeChat -> createWechatSession(client, cookieJar)
+        }
+    }
+
+    private fun createQQSession(
+        client: OkHttpClient,
+        cookieJar: QQMusicLoginCookieJar,
+    ): QQMusicQrLoginSession {
+        val url = "https://ssl.ptlogin2.qq.com/ptqrshow".toHttpUrl().newBuilder()
+            .addQueryParameter("appid", QQ_QR_APP_ID)
+            .addQueryParameter("e", "2")
+            .addQueryParameter("l", "M")
+            .addQueryParameter("s", "3")
+            .addQueryParameter("d", "72")
+            .addQueryParameter("v", "4")
+            .addQueryParameter("t", (nowMillis() * 1_000_000L).toString())
+            .addQueryParameter("daid", QQ_LOGIN_DAID)
+            .addQueryParameter("pt_3rd_aid", QQ_MUSIC_OAUTH_APP_ID)
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("Referer", "https://xui.ptlogin2.qq.com/")
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+
+        return client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("获取 QQ 登录二维码返回 ${response.code}")
+            }
+            val qrSignature = cookieJar.loadForRequest(url)
+                .firstOrNull { it.name == "qrsig" }
+                ?.value
+                ?: throw IOException("QQ 登录服务没有返回二维码标识")
+            val image = response.body.bytes()
+            if (image.isEmpty()) throw IOException("读取 QQ 登录二维码失败")
+            QQMusicQrLoginSession(
+                method = QQMusicQrLoginMethod.QQ,
+                imageBytes = image,
+                imageMimeType = "image/png",
+                qrToken = qrSignature,
+                expiresAtMillis = nowMillis() + QQ_QR_LOGIN_LIFETIME_MS,
+                httpClient = client,
+                cookieJar = cookieJar,
+            )
+        }
+    }
+
+    private fun createWechatSession(
+        client: OkHttpClient,
+        cookieJar: QQMusicLoginCookieJar,
+    ): QQMusicQrLoginSession {
+        val loginUrl = "https://open.weixin.qq.com/connect/qrconnect".toHttpUrl().newBuilder()
+            .addQueryParameter("appid", QQ_MUSIC_WECHAT_APP_ID)
+            .addQueryParameter("redirect_uri", QQ_MUSIC_WECHAT_REDIRECT_URL)
+            .addQueryParameter("response_type", "code")
+            .addQueryParameter("scope", "snsapi_login")
+            .addQueryParameter("state", "STATE")
+            .build()
+        val pageRequest = Request.Builder()
+            .url(loginUrl)
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        val uuid = client.newCall(pageRequest).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("获取微信登录二维码返回 ${response.code}")
+            }
+            parseQQMusicWechatQrUuid(response.body.string())
+        }
+        val imageUrl = "https://open.weixin.qq.com/connect/qrcode/$uuid".toHttpUrl()
+        val imageRequest = Request.Builder()
+            .url(imageUrl)
+            .header("Referer", loginUrl.toString())
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        return client.newCall(imageRequest).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("读取微信登录二维码返回 ${response.code}")
+            }
+            val image = response.body.bytes()
+            if (image.isEmpty()) throw IOException("读取微信登录二维码失败")
+            QQMusicQrLoginSession(
+                method = QQMusicQrLoginMethod.WeChat,
+                imageBytes = image,
+                imageMimeType = "image/jpeg",
+                qrToken = uuid,
+                expiresAtMillis = nowMillis() + WECHAT_QR_LOGIN_LIFETIME_MS,
+                httpClient = client,
+                cookieJar = cookieJar,
+            )
+        }
+    }
+
+    suspend fun checkSession(session: QQMusicQrLoginSession): QQMusicQrLoginState =
+        withContext(Dispatchers.IO) {
+            if (nowMillis() >= session.expiresAtMillis) return@withContext QQMusicQrLoginState.Expired
+            val result = when (session.method) {
+                QQMusicQrLoginMethod.QQ -> pollQQ(session)
+                QQMusicQrLoginMethod.WeChat -> pollWechat(session)
+            }
+            when (result.event) {
+                QQMusicQrLoginEvent.Waiting -> QQMusicQrLoginState.Waiting
+                QQMusicQrLoginEvent.Scanned -> QQMusicQrLoginState.Scanned
+                QQMusicQrLoginEvent.Expired -> QQMusicQrLoginState.Expired
+                QQMusicQrLoginEvent.Rejected -> QQMusicQrLoginState.Rejected
+                QQMusicQrLoginEvent.Connected -> {
+                    val credential = when (session.method) {
+                        QQMusicQrLoginMethod.QQ -> authorizeQQ(session, result.uin, result.sigX)
+                        QQMusicQrLoginMethod.WeChat -> exchangeWechatCode(
+                            session.httpClient,
+                            result.authorizationCode,
+                        )
+                    }
+                    QQMusicQrLoginState.Authorized(buildQQMusicQrCredentialCookie(credential))
+                }
+            }
+        }
+
+    private fun pollQQ(session: QQMusicQrLoginSession): QQMusicPtuiResult {
+        val url = "https://ssl.ptlogin2.qq.com/ptqrlogin".toHttpUrl().newBuilder()
+            .addQueryParameter("u1", "https://graph.qq.com/oauth2.0/login_jump")
+            .addQueryParameter("ptqrtoken", qqMusicHash33(session.qrToken, 0).toString())
+            .addQueryParameter("ptredirect", "0")
+            .addQueryParameter("h", "1")
+            .addQueryParameter("t", "1")
+            .addQueryParameter("g", "1")
+            .addQueryParameter("from_ui", "1")
+            .addQueryParameter("ptlang", "2052")
+            .addQueryParameter("action", "0-0-${nowMillis()}")
+            .addQueryParameter("js_ver", "20102616")
+            .addQueryParameter("js_type", "1")
+            .addQueryParameter("pt_uistyle", "40")
+            .addQueryParameter("aid", QQ_QR_APP_ID)
+            .addQueryParameter("daid", QQ_LOGIN_DAID)
+            .addQueryParameter("pt_3rd_aid", QQ_MUSIC_OAUTH_APP_ID)
+            .addQueryParameter("has_onekey", "1")
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("Referer", "https://xui.ptlogin2.qq.com/")
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        return session.httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw IOException("查询 QQ 扫码状态返回 ${response.code}")
+            parseQQMusicPtuiCallback(response.body.string())
+        }
+    }
+
+    private fun pollWechat(session: QQMusicQrLoginSession): QQMusicPtuiResult {
+        val urlBuilder = "https://long.open.weixin.qq.com/connect/l/qrconnect".toHttpUrl().newBuilder()
+            .addQueryParameter("uuid", session.qrToken)
+            .addQueryParameter("_", nowMillis().toString())
+        session.lastWechatStatus?.let { urlBuilder.addQueryParameter("last", it.toString()) }
+        val request = Request.Builder()
+            .url(urlBuilder.build())
+            .header("Referer", "https://open.weixin.qq.com/")
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        return try {
+            session.httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw IOException("查询微信扫码状态返回 ${response.code}")
+                parseQQMusicWechatPoll(response.body.string()).also { result ->
+                    session.lastWechatStatus = when (result.event) {
+                        QQMusicQrLoginEvent.Scanned -> 404
+                        else -> null
+                    }
+                }
+            }
+        } catch (_: SocketTimeoutException) {
+            QQMusicPtuiResult(QQMusicQrLoginEvent.Waiting, "请使用微信扫一扫扫码")
+        }
+    }
+
+    private fun authorizeQQ(
+        session: QQMusicQrLoginSession,
+        uin: String,
+        sigX: String,
+    ): QQMusicQrCredential {
+        val checkUrl = "https://ssl.ptlogin2.graph.qq.com/check_sig".toHttpUrl().newBuilder()
+            .addQueryParameter("uin", uin)
+            .addQueryParameter("pttype", "1")
+            .addQueryParameter("service", "ptqrlogin")
+            .addQueryParameter("nodirect", "0")
+            .addQueryParameter("ptsigx", sigX)
+            .addQueryParameter("s_url", "https://graph.qq.com/oauth2.0/login_jump")
+            .addQueryParameter("ptlang", "2052")
+            .addQueryParameter("ptredirect", "100")
+            .addQueryParameter("aid", QQ_QR_APP_ID)
+            .addQueryParameter("daid", QQ_LOGIN_DAID)
+            .addQueryParameter("j_later", "0")
+            .addQueryParameter("low_login_hour", "0")
+            .addQueryParameter("regmaster", "0")
+            .addQueryParameter("pt_login_type", "3")
+            .addQueryParameter("pt_aid", "0")
+            .addQueryParameter("pt_aaid", "16")
+            .addQueryParameter("pt_light", "0")
+            .addQueryParameter("pt_3rd_aid", QQ_MUSIC_OAUTH_APP_ID)
+            .build()
+        val checkRequest = Request.Builder()
+            .url(checkUrl)
+            .header("Referer", "https://xui.ptlogin2.qq.com/")
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        session.httpClient.newCall(checkRequest).execute().use { response ->
+            if (response.code >= 400) throw IOException("QQ 扫码凭据校验返回 ${response.code}")
+        }
+
+        val graphUrl = "https://graph.qq.com/".toHttpUrl()
+        val pSKey = session.cookieJar.loadForRequest(graphUrl)
+            .firstOrNull { it.name == "p_skey" }
+            ?.value
+            .orEmpty()
+        if (pSKey.isBlank()) throw IOException("QQ 扫码校验没有返回授权票据")
+
+        val form = FormBody.Builder()
+            .add("response_type", "code")
+            .add("client_id", QQ_MUSIC_OAUTH_APP_ID)
+            .add("redirect_uri", "https://y.qq.com/portal/wx_redirect.html?login_type=1&surl=https://y.qq.com/")
+            .add("scope", "get_user_info,get_app_friends")
+            .add("state", "state")
+            .add("switch", "")
+            .add("from_ptlogin", "1")
+            .add("src", "1")
+            .add("update_auth", "1")
+            .add("openapi", "1010_1030")
+            .add("g_tk", qqMusicHash33(pSKey, 5381).toString())
+            .add("auth_time", (nowMillis() / 1_000L * 1_000L).toString())
+            .add("ui", randomHex(16))
+            .build()
+        val authorizeRequest = Request.Builder()
+            .url("https://graph.qq.com/oauth2.0/authorize")
+            .post(form)
+            .header("Referer", "https://graph.qq.com/oauth2.0/login_jump")
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        val code = session.httpClient.newCall(authorizeRequest).execute().use { response ->
+            val location = response.header("Location")
+                ?: throw IOException("QQ 音乐授权没有返回登录码")
+            location.toHttpUrlOrNull()?.queryParameter("code")
+                ?.takeIf(String::isNotBlank)
+                ?: throw IOException("QQ 音乐授权没有返回登录码")
+        }
+        return exchangeQQCode(session.httpClient, code)
+    }
+
+    private fun exchangeQQCode(client: OkHttpClient, code: String): QQMusicQrCredential {
+        val payload = JSONObject()
+            .put(
+                "comm",
+                JSONObject()
+                    .put("ct", 24)
+                    .put("cv", 4_747_474)
+                    .put("platform", "yqq.json")
+                    .put("chid", "0")
+                    .put("uin", 0)
+                    .put("g_tk", 5381)
+                    .put("g_tk_new_20200303", 5381)
+                    .put("format", "json")
+                    .put("inCharset", "utf-8")
+                    .put("outCharset", "utf-8")
+                    .put("notice", 0)
+                    .put("needNewCode", 1)
+                    .put("tmeLoginType", 2),
+            )
+            .put(
+                "req_0",
+                JSONObject()
+                    .put("module", "QQConnectLogin.LoginServer")
+                    .put("method", "QQLogin")
+                    .put("param", JSONObject().put("code", code)),
+            )
+        val request = Request.Builder()
+            .url("https://u.y.qq.com/cgi-bin/musicu.fcg")
+            .post(payload.toString().toRequestBody("application/json".toMediaType()))
+            .header("Referer", "https://y.qq.com/")
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        return client.newCall(request).execute().use { response ->
+            val root = runCatching { JSONObject(response.body.string()) }
+                .getOrElse { throw IOException("QQ 音乐登录响应解析失败", it) }
+            val requestResult = root.optJSONObject("req_0") ?: JSONObject()
+            val resultCode = requestResult.optInt("code", -1)
+            if (!response.isSuccessful || root.optInt("code", -1) != 0 || resultCode != 0) {
+                throw IOException("QQ 音乐拒绝了扫码登录（错误码 $resultCode）")
+            }
+            val credential = parseQQMusicQrCredential(
+                requestResult.optJSONObject("data") ?: JSONObject(),
+            )
+            if (credential.musicId.isBlank() || credential.musicKey.isBlank()) {
+                throw IOException("QQ 音乐登录成功但没有返回可用播放凭据")
+            }
+            credential
+        }
+    }
+
+    private fun exchangeWechatCode(client: OkHttpClient, code: String): QQMusicQrCredential {
+        if (code.isBlank()) throw IOException("微信扫码授权没有返回登录码")
+        val request = Request.Builder()
+            .url("https://u.y.qq.com/cgi-bin/musicu.fcg")
+            .post(
+                buildQQMusicWechatLoginPayload(code).toString()
+                    .toRequestBody("application/x-www-form-urlencoded".toMediaType()),
+            )
+            .header("Accept", "*/*")
+            .header("Referer", QQ_MUSIC_WECHAT_REDIRECT_URL)
+            .header("User-Agent", QQ_LOGIN_USER_AGENT)
+            .build()
+        return client.newCall(request).execute().use { response ->
+            val root = runCatching { JSONObject(response.body.string()) }
+                .getOrElse { throw IOException("QQ 音乐微信登录响应解析失败", it) }
+            val requestResult = root.optJSONObject("req") ?: JSONObject()
+            val resultCode = requestResult.optInt("code", -1)
+            if (!response.isSuccessful || root.optInt("code", -1) != 0 || resultCode != 0) {
+                throw IOException("QQ 音乐拒绝了微信扫码登录（错误码 $resultCode）")
+            }
+            val credential = parseQQMusicQrCredential(
+                requestResult.optJSONObject("data") ?: JSONObject(),
+            )
+            if (credential.musicId.isBlank() || credential.musicKey.isBlank()) {
+                throw IOException("QQ 音乐微信登录成功但没有返回可用播放凭据")
+            }
+            credential
+        }
+    }
+}
+
+internal fun parseQQMusicPtuiCallback(raw: String): QQMusicPtuiResult {
+    val callback = Regex("""ptuiCB\((.*)\)""").find(raw.trim())
+        ?: throw IOException("无法解析 QQ 扫码状态")
+    val args = Regex("""'((?:\\.|[^'])*)'""")
+        .findAll(callback.groupValues[1])
+        .map { match ->
+            match.groupValues[1]
+                .replace("\\'", "'")
+                .replace("\\\\", "\\")
+        }
+        .toList()
+    val code = args.firstOrNull()?.toIntOrNull()
+        ?: throw IOException("QQ 扫码状态码无效")
+    return when (code) {
+        0, 405 -> {
+            val callbackUrl = args.getOrNull(2)?.toHttpUrlOrNull()
+                ?: throw IOException("QQ 授权地址无效")
+            val uin = callbackUrl.queryParameter("uin").orEmpty()
+            val sigX = callbackUrl.queryParameter("ptsigx").orEmpty()
+            if (uin.isBlank() || sigX.isBlank()) throw IOException("QQ 授权响应缺少账号参数")
+            QQMusicPtuiResult(QQMusicQrLoginEvent.Connected, "扫码授权成功", uin, sigX)
+        }
+        66, 408 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Waiting, "请使用手机 QQ 扫码")
+        67, 404 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Scanned, "已扫码，请在手机 QQ 上确认")
+        65, 402 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Expired, "二维码已过期，请重新获取")
+        68, 403 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Rejected, "你已取消授权，请重新扫码")
+        else -> throw IOException("未知的 QQ 扫码状态：$code")
+    }
+}
+
+internal fun parseQQMusicWechatQrUuid(html: String): String {
+    val uuid = Regex("""/connect/qrcode/([A-Za-z0-9_-]+)""")
+        .find(html)
+        ?.groupValues
+        ?.getOrNull(1)
+        .orEmpty()
+    if (uuid.isBlank()) throw IOException("微信登录服务没有返回二维码标识")
+    return uuid
+}
+
+internal fun parseQQMusicWechatPoll(raw: String): QQMusicPtuiResult {
+    val status = Regex("""window\.wx_errcode\s*=\s*(\d+)""")
+        .find(raw)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toIntOrNull()
+        ?: throw IOException("无法解析微信扫码状态")
+    return when (status) {
+        405 -> {
+            val code = Regex("""window\.wx_code\s*=\s*['\"]([^'\"]+)['\"]""")
+                .find(raw)
+                ?.groupValues
+                ?.getOrNull(1)
+                .orEmpty()
+            if (code.isBlank()) throw IOException("微信扫码授权没有返回登录码")
+            QQMusicPtuiResult(
+                event = QQMusicQrLoginEvent.Connected,
+                message = "微信扫码授权成功",
+                authorizationCode = code,
+            )
+        }
+        408 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Waiting, "请使用微信扫一扫扫码")
+        404 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Scanned, "已扫码，请在微信中确认")
+        403 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Rejected, "你已取消微信授权，请重新扫码")
+        402 -> QQMusicPtuiResult(QQMusicQrLoginEvent.Expired, "微信二维码已过期，请重新获取")
+        500 -> throw IOException("微信登录服务暂时繁忙，请重新生成二维码")
+        else -> throw IOException("未知的微信扫码状态：$status")
+    }
+}
+
+internal fun buildQQMusicWechatLoginPayload(code: String): JSONObject = JSONObject()
+    .put(
+        "comm",
+        JSONObject()
+            .put("tmeAppID", "qqmusic")
+            .put("tmeLoginType", "1")
+            .put("g_tk", 5381)
+            .put("platform", "yqq")
+            .put("ct", 24)
+            .put("cv", 0),
+    )
+    .put(
+        "req",
+        JSONObject()
+            .put("module", "music.login.LoginServer")
+            .put("method", "Login")
+            .put(
+                "param",
+                JSONObject()
+                    .put("strAppid", QQ_MUSIC_WECHAT_APP_ID)
+                    .put("code", code),
+            ),
+    )
+
+internal fun qqMusicHash33(value: String, seed: Int): Int {
+    var hash = seed.toLong()
+    value.toByteArray(Charsets.UTF_8).forEach { byte ->
+        hash += (hash shl 5) + (byte.toInt() and 0xff)
+    }
+    return (hash and 0x7fffffff).toInt()
+}
+
+internal fun parseQQMusicQrCredential(data: JSONObject): QQMusicQrCredential = QQMusicQrCredential(
+    musicId = data.optString("str_musicid").ifBlank { data.opt("musicid")?.toString().orEmpty() },
+    musicKey = data.optString("musickey"),
+    openId = data.optString("openid"),
+    accessToken = data.optString("access_token"),
+    refreshToken = data.optString("refresh_token"),
+    unionId = data.optString("unionid"),
+    encryptedUin = data.optString("encryptUin"),
+    loginType = data.optInt("loginType", data.optInt("login_type", 0)),
+)
+
+internal fun buildQQMusicQrCredentialCookie(credential: QQMusicQrCredential): String {
+    val uin = credential.musicId.filter(Char::isDigit).trimStart('0')
+    if (uin.isBlank() || credential.musicKey.isBlank()) throw IOException("QQ 音乐登录凭据不完整")
+    val loginType = credential.loginType.takeIf { it != 0 }
+        ?: if (credential.musicKey.startsWith("W_X")) 1 else 2
+    return listOf(
+        "uin" to uin,
+        "qqmusic_uin" to uin,
+        "qm_keyst" to credential.musicKey,
+        "qqmusic_key" to credential.musicKey,
+        "music_key" to credential.musicKey,
+        "login_type" to loginType.toString(),
+        "psrf_qqopenid" to credential.openId,
+        "psrf_qqaccess_token" to credential.accessToken,
+        "psrf_qqrefresh_token" to credential.refreshToken,
+        "psrf_qqunionid" to credential.unionId,
+        "euin" to credential.encryptedUin,
+    ).filter { (_, value) -> value.isNotBlank() && value.none { it == ';' || it == '\r' || it == '\n' } }
+        .joinToString("; ") { (key, value) -> "$key=$value" }
+}
+
+internal class QQMusicLoginCookieJar : CookieJar {
+    private val cookies = linkedMapOf<String, Cookie>()
+
+    @Synchronized
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        cookies.forEach { cookie -> this.cookies[cookieKey(cookie)] = cookie }
+    }
+
+    @Synchronized
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val now = System.currentTimeMillis()
+        cookies.entries.removeAll { (_, cookie) -> cookie.expiresAt < now }
+        return cookies.values.filter { it.matches(url) }
+    }
+
+    private fun cookieKey(cookie: Cookie): String = "${cookie.name}|${cookie.domain}|${cookie.path}"
+}
+
+private fun randomHex(bytes: Int): String {
+    val buffer = ByteArray(bytes)
+    SecureRandom().nextBytes(buffer)
+    return buffer.joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+}

--- a/android/app/src/main/kotlin/com/lladlam/melox/ui/account/QQMusicLoginScreen.kt
+++ b/android/app/src/main/kotlin/com/lladlam/melox/ui/account/QQMusicLoginScreen.kt
@@ -1,68 +1,90 @@
 package com.lladlam.melox.ui.account
 
-import android.annotation.SuppressLint
-import android.graphics.Color as AndroidColor
-import android.os.SystemClock
-import android.util.Log
-import android.webkit.CookieManager
-import android.webkit.WebChromeClient
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import android.Manifest
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.viewinterop.AndroidView
-import com.lladlam.melox.core.provider.qqmusic.QQMusicApiClient
-import com.lladlam.melox.core.provider.qqmusic.QQMusicPhoneAuthClient
-import com.lladlam.melox.core.provider.qqmusic.QQMusicSecurityChallengeException
-import com.lladlam.melox.core.provider.qqmusic.QQMusicSessionStore
+import androidx.core.content.ContextCompat
 import com.lladlam.melox.core.music.provider.PlaybackAccountSlot
-import com.lladlam.melox.core.remoteconfig.MeloXRemoteConfigPolicy
+import com.lladlam.melox.core.provider.qqmusic.QQMusicApiClient
+import com.lladlam.melox.core.provider.qqmusic.QQMusicQrLoginClient
+import com.lladlam.melox.core.provider.qqmusic.QQMusicQrLoginMethod
+import com.lladlam.melox.core.provider.qqmusic.QQMusicQrLoginSession
+import com.lladlam.melox.core.provider.qqmusic.QQMusicQrLoginState
+import com.lladlam.melox.core.provider.qqmusic.QQMusicSessionStore
+import com.lladlam.melox.ui.glass.MeloXSymbol
+import com.lladlam.melox.ui.glass.MeloXSymbolIcon
 import com.lladlam.melox.ui.glass.meloXLiquidButton
-import com.lladlam.melox.ui.glass.MeloXGlassButton
-import com.lladlam.melox.ui.glass.MeloXGlassButtonStyle
-import com.lladlam.melox.ui.glass.MeloXGlassDialog
 import com.lladlam.melox.ui.legal.MeloXLegalLinks
+import java.io.File
+import java.io.FileOutputStream
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-private const val QQ_MUSIC_LOGIN_URL = "https://y.qq.com/"
-private const val COOKIE_POLL_INTERVAL_MS = 500L
-private const val COOKIE_STABLE_POLLS_BEFORE_VERIFY = 3
-private const val VERIFY_RETRY_COOLDOWN_MS = 8_000L
-private const val TAG = "MeloXQQLogin"
-
-@SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun QQMusicLoginScreen(
     onDismiss: () -> Unit,
@@ -70,147 +92,110 @@ fun QQMusicLoginScreen(
     targetSlot: PlaybackAccountSlot = PlaybackAccountSlot.Main,
 ) {
     val context = LocalContext.current.applicationContext
-    val phoneAuthClient = remember { QQMusicPhoneAuthClient() }
+    val client = remember { QQMusicQrLoginClient() }
     val scope = rememberCoroutineScope()
-    var pendingPhone by rememberSaveable { mutableStateOf("") }
-    var resumeAtCodeStep by rememberSaveable { mutableStateOf(false) }
-    var useWebLogin by remember { mutableStateOf(true) }
-    var showQrLoginTip by rememberSaveable { mutableStateOf(true) }
-    var webLoginUrl by remember { mutableStateOf(QQ_MUSIC_LOGIN_URL) }
-    var securityChallengeActive by remember { mutableStateOf(false) }
-    var webView by remember { mutableStateOf<WebView?>(null) }
-    var pageLoading by remember { mutableStateOf(true) }
-    var verifying by remember { mutableStateOf(false) }
-    var securityRetrying by remember { mutableStateOf(false) }
-    var verificationError by remember { mutableStateOf<String?>(null) }
+    var methodName by rememberSaveable { mutableStateOf(QQMusicQrLoginMethod.QQ.name) }
+    val method = QQMusicQrLoginMethod.valueOf(methodName)
+    var qrSession by remember { mutableStateOf<QQMusicQrLoginSession?>(null) }
+    var stateText by remember { mutableStateOf(method.loadingText()) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var actionMessage by remember { mutableStateOf<String?>(null) }
+    var actionFailed by remember { mutableStateOf(false) }
+    var saving by remember { mutableStateOf(false) }
+    var refreshToken by remember { mutableStateOf(0) }
 
-    LaunchedEffect(Unit) {
-        QQMusicSessionStore.clearWebLoginCookies()
+    BackHandler(onBack = onDismiss)
+
+    fun saveCurrentQr() {
+        val current = qrSession ?: return
+        saving = true
+        actionMessage = null
+        scope.launch {
+            runCatchingCancellable {
+                withContext(Dispatchers.IO) { saveQrImageToGallery(context, current) }
+            }.onSuccess { location ->
+                actionFailed = false
+                actionMessage = "二维码已保存到 $location"
+            }.onFailure { failure ->
+                actionFailed = true
+                actionMessage = failure.message ?: "二维码保存失败，请稍后重试"
+            }
+            saving = false
+        }
     }
 
-    BackHandler(enabled = useWebLogin) {
-        val view = webView
-        if (view?.canGoBack() == true) view.goBack() else onDismiss()
+    val storagePermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            saveCurrentQr()
+        } else {
+            actionFailed = true
+            actionMessage = "未获得存储权限，无法保存二维码"
+        }
     }
 
-    LaunchedEffect(webView) {
-        if (webView == null) return@LaunchedEffect
+    LaunchedEffect(method, refreshToken) {
+        sessionLoop@ while (true) {
+            qrSession = null
+            error = null
+            actionMessage = null
+            stateText = method.loadingText()
+            val created = runCatchingCancellable { client.createSession(method) }
+                .onFailure { error = qrErrorMessage(it, "获取${method.displayName()}登录二维码失败") }
+                .getOrNull() ?: return@LaunchedEffect
+            qrSession = created
+            stateText = method.waitingText()
 
-        var previousSessionFingerprint = ""
-        var stablePolls = 0
-        var lastAttemptFingerprint: String? = null
-        var lastAttemptAt = 0L
-
-        while (true) {
-            val candidate = collectQQMusicCookieHeader()
-            val session = QQMusicSessionStore.parse(candidate)
-
-            val sessionFingerprint = if (session.isLoggedIn) "${session.uin}:${session.musicKey}" else ""
-            if (sessionFingerprint != previousSessionFingerprint) {
-                Log.d(TAG, "QQ Music WebView session state changed: available=${sessionFingerprint.isNotBlank()}")
-            }
-            if (sessionFingerprint.isNotBlank() && sessionFingerprint == previousSessionFingerprint) {
-                stablePolls += 1
-            } else {
-                previousSessionFingerprint = sessionFingerprint
-                stablePolls = if (sessionFingerprint.isBlank()) 0 else 1
-            }
-
-            if (!securityChallengeActive && session.isLoggedIn && stablePolls >= COOKIE_STABLE_POLLS_BEFORE_VERIFY && !verifying) {
-                val fingerprint = "${session.uin}:${session.musicKey}"
-                val now = SystemClock.elapsedRealtime()
-                val shouldAttempt =
-                    fingerprint != lastAttemptFingerprint || now - lastAttemptAt >= VERIFY_RETRY_COOLDOWN_MS
-
-                if (shouldAttempt) {
-                    lastAttemptFingerprint = fingerprint
-                    lastAttemptAt = now
-                    verifying = true
-                    verificationError = null
-
-                    val result = runCatching {
-                        QQMusicApiClient(sessionProvider = { session }).accountProfile(session)
+            delay(500)
+            while (true) {
+                val state = runCatchingCancellable { client.checkSession(created) }
+                    .onFailure { error = qrErrorMessage(it, "检查${method.displayName()}扫码状态失败") }
+                    .getOrNull() ?: return@LaunchedEffect
+                when (state) {
+                    QQMusicQrLoginState.Waiting -> stateText = method.waitingText()
+                    QQMusicQrLoginState.Scanned -> stateText = "已扫码，请在${method.displayName()}中确认"
+                    QQMusicQrLoginState.Expired -> {
+                        qrSession = null
+                        stateText = method.loadingText()
+                        delay(250)
+                        continue@sessionLoop
                     }
-
-                    verifying = false
-                    if (result.isSuccess) {
-                        QQMusicSessionStore.write(context, candidate, playback = targetSlot == PlaybackAccountSlot.Playback)
-                        CookieManager.getInstance().flush()
+                    QQMusicQrLoginState.Rejected -> {
+                        stateText = "你已取消授权"
+                        return@LaunchedEffect
+                    }
+                    is QQMusicQrLoginState.Authorized -> {
+                        stateText = "正在验证 QQ音乐登录状态…"
+                        val session = QQMusicSessionStore.parse(state.cookie)
+                        val verified = runCatchingCancellable {
+                            QQMusicApiClient(sessionProvider = { session }).accountProfile(session)
+                        }.onFailure {
+                            error = it.message ?: "QQ音乐登录状态验证失败"
+                        }.isSuccess
+                        if (!verified) return@LaunchedEffect
+                        QQMusicSessionStore.write(
+                            context = context,
+                            cookie = state.cookie,
+                            playback = targetSlot == PlaybackAccountSlot.Playback,
+                        )
+                        stateText = "登录成功"
                         onLoggedIn()
                         return@LaunchedEffect
                     }
-
-                    verificationError = result.exceptionOrNull()?.message
-                        ?: "QQ音乐登录状态验证失败，请稍后重试"
-                    Log.w(TAG, "QQ Music WebView session verification failed", result.exceptionOrNull())
                 }
+                delay(1_100)
             }
-
-            delay(COOKIE_POLL_INTERVAL_MS)
         }
     }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            webView?.stopLoading()
-            webView?.destroy()
-        }
+    LaunchedEffect(actionMessage) {
+        if (actionMessage == null) return@LaunchedEffect
+        delay(4_000)
+        actionMessage = null
     }
 
-    if (!useWebLogin) {
-        MeloXPhoneCodeLoginScreen(
-            serviceName = "QQ音乐",
-            brandColor = Color(0xFF20C573),
-            description = "使用手机号登录 QQ音乐，访问你的收藏与歌单。",
-            onClose = onDismiss,
-            onSendCode = { countryCode, phone ->
-                try {
-                    phoneAuthClient.sendCode(countryCode, phone)
-                    Result.success(Unit)
-                } catch (challenge: QQMusicSecurityChallengeException) {
-                    webLoginUrl = challenge.securityUrl
-                    securityChallengeActive = true
-                    useWebLogin = true
-                    Result.failure(challenge)
-                } catch (error: Exception) {
-                    Result.failure(error)
-                }
-            },
-            onSubmitCode = { countryCode, phone, code ->
-                try {
-                    val cookie = phoneAuthClient.login(countryCode, phone, code)
-                    val parsedSession = QQMusicSessionStore.parse(cookie)
-                    QQMusicApiClient(sessionProvider = { parsedSession }).accountProfile()
-                    QQMusicSessionStore.write(
-                        context,
-                        cookie,
-                        playback = targetSlot == PlaybackAccountSlot.Playback,
-                    )
-                    onLoggedIn()
-                    Result.success(Unit)
-                } catch (challenge: QQMusicSecurityChallengeException) {
-                    webLoginUrl = challenge.securityUrl
-                    securityChallengeActive = true
-                    useWebLogin = true
-                    Result.failure(challenge)
-                } catch (error: Exception) {
-                    Result.failure(error)
-                }
-            },
-            onWebLogin = {
-                webLoginUrl = QQ_MUSIC_LOGIN_URL
-                securityChallengeActive = false
-                useWebLogin = true
-            },
-            webFallbackEmphasis = true,
-            initialPhone = pendingPhone,
-            startAtCodeStep = resumeAtCodeStep,
-            onPhoneChanged = {
-                pendingPhone = it
-                resumeAtCodeStep = false
-            },
-        )
-    } else Column(
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
@@ -219,197 +204,397 @@ fun QQMusicLoginScreen(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 18.dp, vertical = 12.dp),
+                .padding(horizontal = 10.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = if (securityChallengeActive) "返回" else "取消",
+                text = "取消",
                 modifier = Modifier
+                    .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
                     .meloXLiquidButton(
-                        shape = RoundedCornerShape(18.dp),
+                        shape = RoundedCornerShape(24.dp),
                         tint = Color(0xFFFF3147),
                         surfaceColor = Color(0xFFFF3147).copy(alpha = 0.08f),
                         lensRadius = 7.dp,
                         refractionHeight = 11.dp,
                     )
-                    .clickable {
-                        onDismiss()
-                    }
-                    .padding(8.dp),
+                    .clickable(onClick = onDismiss)
+                    .padding(horizontal = 10.dp, vertical = 13.dp),
                 color = Color(0xFFFF3147),
                 fontSize = 16.sp,
+                textAlign = TextAlign.Center,
             )
             Text(
-                text = if (securityChallengeActive) "QQ音乐安全验证" else "登录 QQ音乐",
-                fontSize = 17.sp,
+                text = "登录 QQ音乐",
                 color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Medium,
             )
-            Text(
-                text = if (securityChallengeActive) "验证完成" else "取消",
-                modifier = Modifier
-                    .clip(RoundedCornerShape(18.dp))
-                    .clickable(enabled = securityChallengeActive && !securityRetrying) {
-                        scope.launch {
-                            securityRetrying = true
-                            verificationError = null
-                            runCatching {
-                                phoneAuthClient.sendCode("86", pendingPhone.filter(Char::isDigit))
-                            }.onSuccess {
-                                webView?.stopLoading()
-                                webView?.destroy()
-                                webView = null
-                                securityChallengeActive = false
-                                webLoginUrl = QQ_MUSIC_LOGIN_URL
-                                resumeAtCodeStep = true
-                                useWebLogin = false
-                            }.onFailure { error ->
-                                verificationError = error.message ?: "安全验证尚未生效，请稍后重试"
-                            }
-                            securityRetrying = false
-                        }
-                    }
-                    .padding(8.dp),
-                color = if (securityChallengeActive) Color(0xFF20C573) else Color.Transparent,
-                fontSize = 16.sp,
-            )
+            Spacer(Modifier.size(48.dp))
         }
 
-        if (pageLoading) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        QQMusicLoginMethodSelector(
+            selectedMethod = method,
+            onSelect = { selected ->
+                if (selected != method) methodName = selected.name
+            },
+            modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
+        )
 
-        Box(modifier = Modifier.weight(1f)) {
-            AndroidView(
-                modifier = Modifier.fillMaxSize(),
-                factory = { viewContext ->
-                    WebView(viewContext).apply {
-                        webView = this
-                        setBackgroundColor(AndroidColor.TRANSPARENT)
-
-                        val cookieManager = CookieManager.getInstance()
-                        cookieManager.setAcceptCookie(true)
-                        cookieManager.setAcceptThirdPartyCookies(this, true)
-
-                        settings.javaScriptEnabled = true
-                        settings.domStorageEnabled = true
-                        settings.databaseEnabled = true
-                        settings.useWideViewPort = true
-                        settings.loadWithOverviewMode = true
-                        settings.userAgentString =
-                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
-                                "AppleWebKit/537.36 (KHTML, like Gecko) " +
-                                "Chrome/124.0.0.0 Safari/537.36"
-
-                        webChromeClient = WebChromeClient()
-                        webViewClient = object : WebViewClient() {
-                            private var firstVisiblePageCommitted = false
-
-                            override fun onPageCommitVisible(view: WebView?, url: String?) {
-                                if (!firstVisiblePageCommitted) {
-                                    firstVisiblePageCommitted = true
-                                    pageLoading = false
-                                }
-                                super.onPageCommitVisible(view, url)
-                            }
-
-                            override fun onPageFinished(view: WebView?, url: String?) {
-                                if (!firstVisiblePageCommitted) {
-                                    firstVisiblePageCommitted = true
-                                    pageLoading = false
-                                }
-                                super.onPageFinished(view, url)
-                            }
-                        }
-                        loadUrl(webLoginUrl)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 28.dp, vertical = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                val currentSession = qrSession
+                if (currentSession == null) {
+                    Box(
+                        modifier = Modifier
+                            .size(240.dp)
+                            .clip(RoundedCornerShape(24.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
                     }
-                },
-            )
-
-            if (verifying || securityRetrying) {
-                Row(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .padding(top = 12.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.94f),
-                            shape = RoundedCornerShape(18.dp),
+                } else {
+                    val bitmap = remember(currentSession) {
+                        BitmapFactory.decodeByteArray(
+                            currentSession.imageBytes,
+                            0,
+                            currentSession.imageBytes.size,
                         )
-                        .padding(horizontal = 14.dp, vertical = 10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(9.dp),
+                    }
+                    if (bitmap != null) {
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "QQ音乐${method.displayName()}登录二维码",
+                            modifier = Modifier
+                                .size(240.dp)
+                                .clip(RoundedCornerShape(24.dp))
+                                .background(Color.White)
+                                .padding(12.dp),
+                        )
+                    }
+                }
+
+                Spacer(Modifier.size(16.dp))
+                val actionsEnabled = currentSession != null
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    QrActionButton(
+                        onClick = { refreshToken += 1 },
+                        icon = MeloXSymbol.Refresh,
+                        label = "刷新二维码",
+                        tint = method.accentColor(),
+                        modifier = Modifier.weight(1f),
+                    )
+                    QrActionButton(
+                        onClick = {
+                            if (
+                                Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+                                ContextCompat.checkSelfPermission(
+                                    context,
+                                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                                ) != PackageManager.PERMISSION_GRANTED
+                            ) {
+                                storagePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                            } else {
+                                saveCurrentQr()
+                            }
+                        },
+                        icon = MeloXSymbol.Download,
+                        label = if (saving) "正在保存…" else "保存到相册",
+                        tint = method.accentColor(),
+                        enabled = actionsEnabled && !saving,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                Spacer(Modifier.size(20.dp))
+                Text(
+                    text = stateText,
+                    modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    text = method.instructionText(),
+                    modifier = Modifier.heightIn(min = 40.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 13.sp,
+                    lineHeight = 20.sp,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    text = "登录凭证仅保存在本机，不会上传到 MeloX 服务器。",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 13.sp,
+                    lineHeight = 20.sp,
+                    textAlign = TextAlign.Center,
+                )
+                actionMessage?.let { message ->
+                    Spacer(Modifier.size(12.dp))
                     Text(
-                        text = if (securityRetrying) "正在重新发送验证码…" else "正在验证 QQ音乐登录状态…",
-                        color = MaterialTheme.colorScheme.onSurface,
+                        text = message,
+                        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+                        color = if (actionFailed) MaterialTheme.colorScheme.error else Color(0xFF168A4A),
                         fontSize = 13.sp,
+                        lineHeight = 20.sp,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                error?.let { message ->
+                    Spacer(Modifier.size(14.dp))
+                    Text(
+                        text = message,
+                        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+                        color = MaterialTheme.colorScheme.error,
+                        fontSize = 13.sp,
+                        lineHeight = 20.sp,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                if (
+                    stateText == "你已取消授权" ||
+                    error != null
+                ) {
+                    Spacer(Modifier.size(18.dp))
+                    QrActionButton(
+                        onClick = { refreshToken += 1 },
+                        icon = MeloXSymbol.Refresh,
+                        label = "重新生成二维码",
+                        tint = method.accentColor(),
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
             }
-
-            verificationError?.let { message ->
-                Text(
-                    text = message,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(16.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.errorContainer,
-                            shape = MaterialTheme.shapes.medium,
-                        )
-                        .padding(horizontal = 14.dp, vertical = 10.dp),
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    fontSize = 13.sp,
-                )
-            }
         }
+
         MeloXLegalLinks(
             modifier = Modifier.padding(vertical = 6.dp),
             tint = Color(0xFF20C573),
         )
     }
-    if (showQrLoginTip) {
-        MeloXGlassDialog(visible = true, onDismiss = { showQrLoginTip = false }) {
-            Text("QQ 登录提示", style = MaterialTheme.typography.titleLarge)
-            Text(
-                "如果使用 QQ 扫码登录，请先截图二维码，再把 MeloX 挂到小窗，然后前往 QQ 扫描截图中的二维码，否则可能无法完成登录。",
-                modifier = Modifier.padding(top = 10.dp),
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.68f),
-                lineHeight = 21.sp,
+}
+
+@Composable
+private fun QQMusicLoginMethodSelector(
+    selectedMethod: QQMusicQrLoginMethod,
+    onSelect: (QQMusicQrLoginMethod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .meloXLiquidButton(
+                shape = RoundedCornerShape(24.dp),
+                surfaceColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.08f),
+                lensRadius = 12.dp,
+                refractionHeight = 14.dp,
             )
-            MeloXGlassButton(
-                onClick = { showQrLoginTip = false },
-                modifier = Modifier.fillMaxWidth().padding(top = 18.dp),
-                style = MeloXGlassButtonStyle.BorderedProminent,
-            ) { Text("知道了") }
+            .padding(4.dp),
+    ) {
+        val segmentWidth = maxWidth / 2
+        val indicatorOffset by animateDpAsState(
+            targetValue = if (selectedMethod == QQMusicQrLoginMethod.QQ) 0.dp else segmentWidth,
+            animationSpec = tween(durationMillis = 280, easing = FastOutSlowInEasing),
+            label = "QQMusicLoginMethodIndicatorOffset",
+        )
+        val indicatorColor by animateColorAsState(
+            targetValue = selectedMethod.accentColor(),
+            animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+            label = "QQMusicLoginMethodIndicatorColor",
+        )
+
+        Box(
+            modifier = Modifier
+                .width(segmentWidth)
+                .fillMaxHeight()
+                .graphicsLayer { translationX = indicatorOffset.toPx() }
+                .meloXLiquidButton(
+                    shape = RoundedCornerShape(20.dp),
+                    tint = indicatorColor,
+                    surfaceColor = indicatorColor.copy(alpha = 0.10f),
+                    lensRadius = 8.dp,
+                    refractionHeight = 10.dp,
+                )
+        )
+
+        Row(modifier = Modifier.fillMaxSize()) {
+            QQMusicQrLoginMethod.entries.forEach { method ->
+                val selected = method == selectedMethod
+                val accent = method.accentColor()
+                val labelColor by animateColorAsState(
+                    targetValue = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant,
+                    animationSpec = tween(durationMillis = 180, easing = FastOutSlowInEasing),
+                    label = "${method.name}LoginMethodLabelColor",
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .selectable(
+                            selected = selected,
+                            role = Role.Tab,
+                            onClick = { onSelect(method) },
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "${method.displayName()}扫码",
+                        color = labelColor,
+                        fontSize = 15.sp,
+                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                    )
+                }
+            }
         }
     }
 }
 
-private fun collectQQMusicCookieHeader(): String {
-    val manager = CookieManager.getInstance()
-    val values = linkedMapOf<String, String>()
-    val urls = listOf(
-        "https://y.qq.com/",
-        "https://u.y.qq.com/",
-        "https://c.y.qq.com/",
-        "https://c6.y.qq.com/",
-        "https://ssl.ptlogin2.qq.com/",
-        "https://ptlogin2.qq.com/",
-        "https://ptlogin2.music.qq.com/",
-        "https://ui.ptlogin2.qq.com/",
-        "https://xui.ptlogin2.qq.com/",
-        "https://music.qq.com/",
-        "https://qq.com/",
-    )
-    urls.forEach { url ->
-        manager.getCookie(url)
-            ?.split(';')
-            ?.forEach { item ->
-                val parts = item.trim().split('=', limit = 2)
-                if (parts.size == 2 && parts[0].isNotBlank()) {
-                    values[parts[0].trim()] = parts[1].trim()
-                }
-            }
+@Composable
+private fun QrActionButton(
+    onClick: () -> Unit,
+    icon: MeloXSymbol,
+    label: String,
+    tint: Color,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Row(
+        modifier = modifier
+            .heightIn(min = 48.dp)
+            .meloXLiquidButton(
+                shape = RoundedCornerShape(18.dp),
+                enabled = enabled,
+                tint = tint,
+                surfaceColor = tint.copy(alpha = 0.08f),
+                lensRadius = 9.dp,
+                refractionHeight = 12.dp,
+            )
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MeloXSymbolIcon(
+            symbol = icon,
+            modifier = Modifier.size(16.dp),
+            color = tint.copy(alpha = if (enabled) 1f else 0.42f),
+            iconSize = 16.sp,
+            contentDescription = label,
+        )
+        Spacer(Modifier.size(6.dp))
+        Text(
+            text = label,
+            color = tint.copy(alpha = if (enabled) 1f else 0.42f),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+        )
     }
-    return values.toSortedMap().entries.joinToString("; ") { (key, value) -> "$key=$value" }
+}
+
+private fun QQMusicQrLoginMethod.displayName(): String = when (this) {
+    QQMusicQrLoginMethod.QQ -> "QQ"
+    QQMusicQrLoginMethod.WeChat -> "微信"
+}
+
+private fun QQMusicQrLoginMethod.loadingText(): String = "正在获取${displayName()}登录二维码…"
+
+private fun QQMusicQrLoginMethod.waitingText(): String = when (this) {
+    QQMusicQrLoginMethod.QQ -> "请使用手机 QQ 扫码"
+    QQMusicQrLoginMethod.WeChat -> "请使用微信扫一扫扫码"
+}
+
+private fun QQMusicQrLoginMethod.instructionText(): String = when (this) {
+    QQMusicQrLoginMethod.QQ -> "扫码并在 QQ 中确认即可登录。也可以保存二维码，再从 QQ 扫一扫的相册中选择。"
+    QQMusicQrLoginMethod.WeChat -> "扫码并在微信中确认即可登录。也可以保存二维码，再从微信扫一扫的相册中选择。"
+}
+
+private fun QQMusicQrLoginMethod.accentColor(): Color = when (this) {
+    QQMusicQrLoginMethod.QQ -> Color(0xFF1096C2)
+    QQMusicQrLoginMethod.WeChat -> Color(0xFF168A4A)
+}
+
+private suspend fun <T> runCatchingCancellable(block: suspend () -> T): Result<T> = try {
+    Result.success(block())
+} catch (cancelled: CancellationException) {
+    throw cancelled
+} catch (failure: Throwable) {
+    Result.failure(failure)
+}
+
+private fun qrErrorMessage(error: Throwable, fallback: String): String {
+    val message = error.message?.trim().orEmpty()
+    return when {
+        message.equals("timeout", ignoreCase = true) -> "网络请求超时，请点击刷新二维码重试"
+        message.isBlank() -> fallback
+        else -> message
+    }
+}
+
+private fun saveQrImageToGallery(
+    context: Context,
+    session: QQMusicQrLoginSession,
+): String {
+    val extension = if (session.imageMimeType == "image/jpeg") "jpg" else "png"
+    val methodName = if (session.method == QQMusicQrLoginMethod.WeChat) "WeChat" else "QQ"
+    val fileName = "MeloX-QQMusic-$methodName-${System.currentTimeMillis()}.$extension"
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+            put(MediaStore.Images.Media.MIME_TYPE, session.imageMimeType)
+            put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/MeloX")
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+        val resolver = context.contentResolver
+        val target = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+            ?: error("无法创建系统图片")
+        runCatching {
+            resolver.openOutputStream(target)?.use { output -> output.write(session.imageBytes) }
+                ?: error("无法写入系统图片")
+            resolver.update(
+                target,
+                ContentValues().apply { put(MediaStore.Images.Media.IS_PENDING, 0) },
+                null,
+                null,
+            )
+        }.getOrElse { failure ->
+            resolver.delete(target, null, null)
+            throw failure
+        }
+    } else {
+        @Suppress("DEPRECATION")
+        val directory = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
+            "MeloX",
+        )
+        check(directory.exists() || directory.mkdirs()) { "无法创建 Pictures/MeloX 文件夹" }
+        val target = File(directory, fileName)
+        FileOutputStream(target).use { output -> output.write(session.imageBytes) }
+        MediaScannerConnection.scanFile(
+            context,
+            arrayOf(target.absolutePath),
+            arrayOf(session.imageMimeType),
+            null,
+        )
+    }
+    return "Pictures/MeloX"
 }

--- a/android/app/src/test/kotlin/com/lladlam/melox/core/provider/qqmusic/QQMusicQrLoginClientTest.kt
+++ b/android/app/src/test/kotlin/com/lladlam/melox/core/provider/qqmusic/QQMusicQrLoginClientTest.kt
@@ -1,0 +1,95 @@
+package com.lladlam.melox.core.provider.qqmusic
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QQMusicQrLoginClientTest {
+    @Test
+    fun parsesQrLoginStates() {
+        assertEquals(
+            QQMusicQrLoginEvent.Waiting,
+            parseQQMusicPtuiCallback("ptuiCB('66','0','','0','二维码未失效。','')").event,
+        )
+        assertEquals(
+            QQMusicQrLoginEvent.Scanned,
+            parseQQMusicPtuiCallback("ptuiCB('67','0','','0','二维码认证中。','')").event,
+        )
+
+        val connected = parseQQMusicPtuiCallback(
+            "ptuiCB('0','0','https://graph.qq.com/oauth2.0/login_jump?ptsigx=sig-value&uin=12345678','0','登录成功！','')",
+        )
+        assertEquals(QQMusicQrLoginEvent.Connected, connected.event)
+        assertEquals("12345678", connected.uin)
+        assertEquals("sig-value", connected.sigX)
+    }
+
+    @Test
+    fun parsesWechatQrPageAndPollingStates() {
+        assertEquals(
+            "wechat-uuid",
+            parseQQMusicWechatQrUuid(
+                """<img class="qrcode" src="/connect/qrcode/wechat-uuid"/>""",
+            ),
+        )
+        assertEquals(
+            QQMusicQrLoginEvent.Waiting,
+            parseQQMusicWechatPoll("window.wx_errcode=408; window.wx_code='';").event,
+        )
+        assertEquals(
+            QQMusicQrLoginEvent.Scanned,
+            parseQQMusicWechatPoll("window.wx_errcode=404; window.wx_code='';").event,
+        )
+        val connected = parseQQMusicWechatPoll(
+            "window.wx_errcode=405; window.wx_code='wechat-code';",
+        )
+        assertEquals(QQMusicQrLoginEvent.Connected, connected.event)
+        assertEquals("wechat-code", connected.authorizationCode)
+        assertEquals(
+            QQMusicQrLoginEvent.Rejected,
+            parseQQMusicWechatPoll("window.wx_errcode=403;").event,
+        )
+        assertEquals(
+            QQMusicQrLoginEvent.Expired,
+            parseQQMusicWechatPoll("window.wx_errcode=402;").event,
+        )
+    }
+
+    @Test
+    fun buildsOfficialWechatCodeExchangeShape() {
+        val payload = buildQQMusicWechatLoginPayload("wechat-code")
+        assertEquals("qqmusic", payload.getJSONObject("comm").getString("tmeAppID"))
+        assertEquals("1", payload.getJSONObject("comm").getString("tmeLoginType"))
+        val request = payload.getJSONObject("req")
+        assertEquals("music.login.LoginServer", request.getString("module"))
+        assertEquals("Login", request.getString("method"))
+        assertEquals("wx48db31d50e334801", request.getJSONObject("param").getString("strAppid"))
+        assertEquals("wechat-code", request.getJSONObject("param").getString("code"))
+    }
+
+    @Test
+    fun hash33MatchesQqLoginProtocol() {
+        assertEquals(1_968_809_247, qqMusicHash33("example-qrsig", 0))
+        assertEquals(193_496_974, qqMusicHash33("key", 5381))
+    }
+
+    @Test
+    fun credentialCreatesExistingSessionCookieShape() {
+        val credential = parseQQMusicQrCredential(
+            JSONObject()
+                .put("musicid", 12_345_678)
+                .put("musickey", "play-key")
+                .put("openid", "open-id")
+                .put("loginType", 2),
+        )
+
+        val cookie = buildQQMusicQrCredentialCookie(credential)
+        val session = QQMusicSessionStore.parse(cookie)
+
+        assertEquals("12345678", session.uin)
+        assertEquals("play-key", session.musicKey)
+        assertTrue(cookie.contains("psrf_qqopenid=open-id"))
+        assertTrue(session.isLoggedIn)
+    }
+}


### PR DESCRIPTION
## Summary

- replace the QQ Music WebView login with native QQ and WeChat QR authorization flows
- add manual refresh, silent QR renewal on expiry, and save-to-gallery support
- add an animated liquid selector for switching between QQ and WeChat login
- keep polling cancellation-aware so Compose lifecycle cancellation is not shown as an error
- preserve the existing local-only credential storage and verify the account before saving it

## Testing

- `:app:testDebugUnitTest` — 219 tests, 0 failures, 1 skipped
- `:app:assembleDebug`
- manually verified QQ and WeChat QR generation, rapid switching/refresh, and saving images to `Pictures/MeloX` on an Android emulator

## Notes

- completing the external authorization still requires a real phone running QQ or WeChat
